### PR TITLE
FLOW: Create Membership Create Data Processing Event Listener

### DIFF
--- a/force-app/main/default/flexipages/SalesCloudMobile_UtilityBar.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/SalesCloudMobile_UtilityBar.flexipage-meta.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexiPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>The default utility bar for the Sales Cloud Mobile application.</description>
+    <flexiPageRegions>
+        <itemInstances>
+            <componentInstance>
+                <componentName>runtime_sales_todo_list:unifiedToDoListAuraWrapper</componentName>
+                <identifier>runtime_sales_todo_list_unifiedToDoListAuraWrapper</identifier>
+            </componentInstance>
+        </itemInstances>
+        <name>utilityItems</name>
+        <type>Region</type>
+    </flexiPageRegions>
+    <masterLabel>Sales Cloud Mobile App Utility Bar</masterLabel>
+    <template>
+        <name>one:utilityBarTemplateDesktop</name>
+    </template>
+    <type>UtilityBar</type>
+</FlexiPage>

--- a/force-app/main/default/flows/DPEV_Listener_Membership_Create_Flow.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Membership_Create_Flow.flow-meta.xml
@@ -53,7 +53,7 @@
             <assignToReference>newMembership.Primary_Contact__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <elementReference>Query_Membership_Form_Submission.Contact__c</elementReference>
+                <elementReference>Query_Membership_Form_Submission.Recipient__c</elementReference>
             </value>
         </assignmentItems>
         <assignmentItems>

--- a/force-app/main/default/flows/DPEV_Listener_Membership_Create_Flow.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Membership_Create_Flow.flow-meta.xml
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <assignments>
+        <description>Create a membership record with the following: Product__c = purchased product Contact__c = recipient contact on the membership form submission Account__c = recipient account on the membership form submission End Date = calculate the correct end date based upon the product purchased</description>
+        <name>Map_Membership_Variables</name>
+        <label>Map Membership Variables</label>
+        <locationX>176</locationX>
+        <locationY>386</locationY>
+        <assignmentItems>
+            <assignToReference>newMembership.Account__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Query_Membership_Form_Submission.Account__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.Opportunity__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Query_Membership_Form_Submission.Opportunity__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.Product__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Query_Opportunity_Product.Product2Id</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.Start_Date__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>$Flow.CurrentDate</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.Status__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Current</stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.Name</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>membershipName</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.Primary_Contact__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Query_Membership_Form_Submission.Contact__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>newMembership.End_Date__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>calculatedEndDate</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Create_Membership</targetReference>
+        </connector>
+    </assignments>
+    <description>Listens for the Platform Event: Create Membership, and creates a Membership record based on data in the Membership Form Submission.</description>
+    <environments>Default</environments>
+    <formulas>
+        <name>calculatedEndDate</name>
+        <dataType>Date</dataType>
+        <expression>IF(
+TEXT({!Query_Opportunity_Product.Product2.Term_Unit__c}) = &apos;Day&apos;,
+{!newMembership.Start_Date__c} + {!Query_Opportunity_Product.Product2.Term__c},
+  IF(
+       TEXT( {!Query_Opportunity_Product.Product2.Term_Unit__c} )= &apos;Week&apos;,
+        {!newMembership.Start_Date__c} + ({!Query_Opportunity_Product.Product2.Term__c}*7),
+         IF(
+                    TEXT(  {!Query_Opportunity_Product.Product2.Term_Unit__c}) = &apos;Month&apos;,
+                             {!newMembership.Start_Date__c} + ({!Query_Opportunity_Product.Product2.Term__c}*30.14),
+                 IF(
+                    TEXT(  {!Query_Opportunity_Product.Product2.Term_Unit__c}) = &apos;Year&apos;,
+                                  {!newMembership.Start_Date__c} + ({!Query_Opportunity_Product.Product2.Term__c}*364),
+                                  null                                   
+                    )
+             )
+  )
+
+)</expression>
+    </formulas>
+    <formulas>
+        <name>membershipName</name>
+        <dataType>String</dataType>
+        <expression>LEFT(
+{!Query_Membership_Form_Submission.Account__r.Name}
++&quot; _ &quot;+
+{!Query_Opportunity_Product.Product2.Name}
++&quot; _ &quot;+
+TEXT({!$Flow.CurrentDate})
+
+,80)</expression>
+    </formulas>
+    <interviewLabel>DPEV Listener - Membership Create Flow {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>DPEV Listener - Membership Create Flow</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>AutoLaunchedFlow</processType>
+    <recordCreates>
+        <name>Create_Membership</name>
+        <label>Create Membership</label>
+        <locationX>176</locationX>
+        <locationY>494</locationY>
+        <inputReference>newMembership</inputReference>
+    </recordCreates>
+    <recordLookups>
+        <description>retrieve the Membership Form Submission that created the Platform Event.</description>
+        <name>Query_Membership_Form_Submission</name>
+        <label>Query Membership Form Submission</label>
+        <locationX>176</locationX>
+        <locationY>170</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Query_Opportunity_Product</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Id</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>$Record.Record_Id__c</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>Membership_Form_Submission__c</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <description>Link the most recently created product on the opportunity line item for the opportunity linked to the membership form submission</description>
+        <name>Query_Opportunity_Product</name>
+        <label>Query Opportunity Product</label>
+        <locationX>176</locationX>
+        <locationY>278</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Map_Membership_Variables</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>OpportunityId</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>Query_Membership_Form_Submission.Opportunity__c</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>OpportunityLineItem</object>
+        <sortField>CreatedDate</sortField>
+        <sortOrder>Desc</sortOrder>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <start>
+        <locationX>50</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Query_Membership_Form_Submission</targetReference>
+        </connector>
+        <object>DPEV_Create_Membership__e</object>
+        <triggerType>PlatformEvent</triggerType>
+    </start>
+    <status>Draft</status>
+    <variables>
+        <name>newMembership</name>
+        <dataType>SObject</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Membership__c</objectType>
+    </variables>
+</Flow>

--- a/force-app/main/default/objects/Membership_Create_DPEV__e/Membership_Create_DPEV__e.object-meta.xml
+++ b/force-app/main/default/objects/Membership_Create_DPEV__e/Membership_Create_DPEV__e.object-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>Membership Create - Description: DATA PROCESSING EVENT: Create a membership using data from a supplied record Id | Fields: Record Id (Text 20)</description>
+    <eventType>HighVolume</eventType>
+    <label>Membership Create - DPEV</label>
+    <pluralLabel>Membership Create - DPEVs</pluralLabel>
+    <publishBehavior>PublishAfterCommit</publishBehavior>
+</CustomObject>

--- a/force-app/main/default/objects/Membership_Create_DPEV__e/fields/Record_Id__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Create_DPEV__e/fields/Record_Id__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Record_Id__c</fullName>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Record Id</label>
+    <length>20</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Membership_Form_Submission__c/fields/Recipient__c.field-meta.xml
+++ b/force-app/main/default/objects/Membership_Form_Submission__c/fields/Recipient__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Recipient__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>Recipient</label>
+    <referenceTo>Contact</referenceTo>
+    <relationshipLabel>Membership Form Submissions (Recipient)</relationshipLabel>
+    <relationshipName>Membership_Form_Submissions1</relationshipName>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/force-app/main/default/objects/User/listViews/All_Users.listView-meta.xml
+++ b/force-app/main/default/objects/User/listViews/All_Users.listView-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ListView xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>All_Users</fullName>
+    <columns>FULL_NAME</columns>
+    <columns>CORE.USERS.ALIAS</columns>
+    <columns>CORE.USERS.USERNAME</columns>
+    <columns>CORE.USER_ROLE.NAME</columns>
+    <columns>CORE.USERS.ACTIVE</columns>
+    <columns>CORE.PROFILE.NAME</columns>
+    <filterScope>Everything</filterScope>
+    <label>All Users</label>
+    <language>en_US</language>
+</ListView>


### PR DESCRIPTION
A few questions were outstanding at time of submit:

Is there a naming convention for Membership Name, as it is not autonumber. Currently I have Account  Name - Product Name - Today’s date - No, not yet, this seems a good start
** ok left as is. 


Is the Start Date today? I don’t see a date in the form submission. Is it related to Grace Period in any way? Start date should be created date on the MFS if it's new, otherwise don't touch.
** left as today. 


Is the Status always ‘current’? Yes - different process handles expiration
** 'current' is set

Do we leave Type field blank? There is a picklist on membership (Individual, Organization, Household) and a free text field on the membership form submission. Also don’t seem to be able to determine the type from the account. I think we should probably add this...
** left as is for now as picklist is restricted. Can revisit logic?

# Critical Changes

New Flow added to create membership

# Changes

n/a

# Issues Closed