### PR TITLE
Create a ScreenFlow to Test/Fix/Correct Membership Form Submission

### DIFF
--- a/force-app/main/default/flows/Membership_Essentials_Platform_Event_Testing.flow-meta.xml
+++ b/force-app/main/default/flows/Membership_Essentials_Platform_Event_Testing.flow-meta.xml
@@ -1,0 +1,701 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <choices>
+        <name>DPEV_Account_choice</name>
+        <choiceText>DPEV - Account</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Account</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Contact_Finder_Choice</name>
+        <choiceText>DPEV - Contact Finder</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Contact Finder</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Create_Membership_Choice</name>
+        <choiceText>DPEV - Create Membership</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV Create Membership</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Create_Opportunity_choice</name>
+        <choiceText>DPEV - Create Opportunity</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV Create Opportunity</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Extend_Membership_choice</name>
+        <choiceText>DPEV - Extend Membership</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV Extend Membership</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Find_Campaign_choice</name>
+        <choiceText>DPEV - Find Campaign</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Find Campaign</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Gift_Recipient_Finder_choice</name>
+        <choiceText>DPEV - Gift Recipient Finder</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Gift Recipient Finder</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Membership_Downgrade_choice</name>
+        <choiceText>DPEV - Membership Downgrade</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV Membership Downgrade</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Membership_Finder_choice</name>
+        <choiceText>DPEV - Membership Finder</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Membership Finder</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Membership_Renewal_choice</name>
+        <choiceText>DPEV - Membership Renewal</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Membership Renewal</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Membership_Upgrade_choice</name>
+        <choiceText>DPEV - Membership Upgrade</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Membership Upgrade</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Pricebook_Finder_choice</name>
+        <choiceText>DPEV - Pricebook Finder</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Pricebook Finder</stringValue>
+        </value>
+    </choices>
+    <choices>
+        <name>DPEV_Product_Finder_choice</name>
+        <choiceText>DPEV - Product Finder</choiceText>
+        <dataType>String</dataType>
+        <value>
+            <stringValue>DPEV - Product Finder</stringValue>
+        </value>
+    </choices>
+    <decisions>
+        <description>Determines which Platform Event was the selected to be tested.</description>
+        <name>Palform_Event_Selected_is</name>
+        <label>Platform Event Selected is...</label>
+        <locationX>1766</locationX>
+        <locationY>458</locationY>
+        <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
+        <rules>
+            <name>DPEV_Account</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Account</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Account_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV-Account</label>
+        </rules>
+        <rules>
+            <name>DPEV_Contact_Finder</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Contact Finder</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Contact_Finder_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Contact Finder</label>
+        </rules>
+        <rules>
+            <name>DPEV_Find_Campaign</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Find Campaign</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Find_Campaign_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Find Campaign</label>
+        </rules>
+        <rules>
+            <name>DPEV_Gift_Recipient_Finder</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Gift Recipient Finder</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Gift_Recipient_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Gift Recipient Finder</label>
+        </rules>
+        <rules>
+            <name>DPEV_Membership_Finder</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Membership Finder</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Membership_Finder_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Membership Finder</label>
+        </rules>
+        <rules>
+            <name>DPEV_Membership_Renewal</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Membership Renewal</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Membership_Renewal_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Membership Renewal</label>
+        </rules>
+        <rules>
+            <name>DPEV_Membership_Upgrade</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Membership Upgrade</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Membership_Upgrade_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Membership Upgrade</label>
+        </rules>
+        <rules>
+            <name>DPEV_Pricebook_Finder</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Pricebook Finder</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Pricebook_Finder_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Pricebook Finder</label>
+        </rules>
+        <rules>
+            <name>DPEV_Product_Finder</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV - Product Finder</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Product_Finder_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV - Product Finder</label>
+        </rules>
+        <rules>
+            <name>DPEV_Create_Membership</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV Create Membership</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Create_Membership_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV Create Membership</label>
+        </rules>
+        <rules>
+            <name>DPEV_Create_Opportunity</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV Create Opportunity</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Create_Membership_Opportunity_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV Create Opportunity</label>
+        </rules>
+        <rules>
+            <name>DPEV_Extend_Membership</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV Extend Membership</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Extend_Membership_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV Extend Membership</label>
+        </rules>
+        <rules>
+            <name>DPEV_Membership_Downgrade</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Select_a_Platform_Event_you_want_to_test</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <stringValue>DPEV Membership Downgrade</stringValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>DPEV_Membership_Downgrade_Create_Platform_Event</targetReference>
+            </connector>
+            <label>DPEV Membership Downgrade</label>
+        </rules>
+    </decisions>
+    <description>Use this flow to test platform events with a selected record.  This allows for testing platform events our of sequence.</description>
+    <dynamicChoiceSets>
+        <name>MbrEssent_Platform_Event_Choices</name>
+        <dataType>String</dataType>
+        <displayField>Label</displayField>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Label</field>
+            <operator>StartsWith</operator>
+            <value>
+                <stringValue>DPEV</stringValue>
+            </value>
+        </filters>
+        <object>PlatformAction</object>
+        <sortField>Label</sortField>
+        <sortOrder>Asc</sortOrder>
+        <valueField>Label</valueField>
+    </dynamicChoiceSets>
+    <environments>Default</environments>
+    <interviewLabel>Membership Essentials - Platform Event Testing {!$Flow.CurrentDateTime}</interviewLabel>
+    <label>Membership Essentials - Platform Event Testing</label>
+    <processMetadataValues>
+        <name>BuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>AUTO_LAYOUT_CANVAS</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>OriginBuilderType</name>
+        <value>
+            <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processType>Flow</processType>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Account.</description>
+        <name>DPEV_Account_Platform_Event</name>
+        <label>DPEV - Account Platform Event</label>
+        <locationX>50</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Account__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Contact Finder</description>
+        <name>DPEV_Contact_Finder_Create_Platform_Event</name>
+        <label>DPEV - Contact Finder Create Platform Event</label>
+        <locationX>314</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Membership_Form_Submission_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Contact_Finder__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Create Membership</description>
+        <name>DPEV_Create_Membership_Create_Platform_Event</name>
+        <label>DPEV Create Membership Create Platform Event</label>
+        <locationX>2426</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Create_Membership__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Create Membership Opportunity</description>
+        <name>DPEV_Create_Membership_Opportunity_Create_Platform_Event</name>
+        <label>DPEV Create Membership Opportunity Create Platform Event</label>
+        <locationX>2690</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Membership_Upgrade__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Extend Membership</description>
+        <name>DPEV_Extend_Membership_Create_Platform_Event</name>
+        <label>DPEV Extend Membership Create Platform Event</label>
+        <locationX>2954</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Membership_Upgrade__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Find Camapaign</description>
+        <name>DPEV_Find_Campaign_Create_Platform_Event</name>
+        <label>DPEV - Find Campaign Create Platform Event</label>
+        <locationX>578</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Find_Campaign__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Gift Recipient</description>
+        <name>DPEV_Gift_Recipient_Create_Platform_Event</name>
+        <label>DPEV Gift Recipient Create Platform Event</label>
+        <locationX>842</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Gift_Recipient_Finder__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Membership Downgrade</description>
+        <name>DPEV_Membership_Downgrade_Create_Platform_Event</name>
+        <label>DPEV Membership Downgrade Create Platform Event</label>
+        <locationX>3218</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Membership_Downgrade__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Membership Finder</description>
+        <name>DPEV_Membership_Finder_Create_Platform_Event</name>
+        <label>DPEV Membership Finder Create Platform Event</label>
+        <locationX>1106</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Membership_Finder__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Membership Renewal</description>
+        <name>DPEV_Membership_Renewal_Create_Platform_Event</name>
+        <label>DPEV Membership Renewal Create Platform Event</label>
+        <locationX>1370</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Membership_Renewal__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Membership Upgrade</description>
+        <name>DPEV_Membership_Upgrade_Create_Platform_Event</name>
+        <label>DPEV Membership Upgrade Create Platform Event</label>
+        <locationX>1634</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Membership_Upgrade__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Pricebook Finder</description>
+        <name>DPEV_Pricebook_Finder_Create_Platform_Event</name>
+        <label>DPEV Pricebook Finder Create Platform Event</label>
+        <locationX>1898</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Pricebook_Finder__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
+        <description>Creates a platform event for DPEV Product Finder</description>
+        <name>DPEV_Product_Finder_Create_Platform_Event</name>
+        <label>DPEV Product Finder Create Platform Event</label>
+        <locationX>2162</locationX>
+        <locationY>566</locationY>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Membership_Form_Submissions_Found_Data_Table.firstSelectedRow.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>DPEV_Product_Finder__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordLookups>
+        <name>Find_Membership_Form_Submission</name>
+        <label>Find Membership Form Submission</label>
+        <locationX>1766</locationX>
+        <locationY>242</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Membership_Essentials_Select_test_record</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Name</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>Membership_Form_Submission_Name</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>false</getFirstRecordOnly>
+        <object>Membership_Form_Submission__c</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <screens>
+        <description>Present a user with a scree to select the record they want to test along with the option of which platform event they want to test.  Allows for testing events later in the business process.</description>
+        <name>Membership_Essentials_Select_test_record</name>
+        <label>Membership Essentials - Select Test Record</label>
+        <locationX>1766</locationX>
+        <locationY>350</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>true</allowPause>
+        <connector>
+            <targetReference>Palform_Event_Selected_is</targetReference>
+        </connector>
+        <fields>
+            <name>Membership_Form_Submissions_Found_Data_Table</name>
+            <dataTypeMappings>
+                <typeName>T</typeName>
+                <typeValue>Membership_Form_Submission__c</typeValue>
+            </dataTypeMappings>
+            <extensionName>flowruntime:datatable</extensionName>
+            <fieldType>ComponentInstance</fieldType>
+            <inputParameters>
+                <name>label</name>
+                <value>
+                    <stringValue>Select a Membership Form Submission to Proceed With</stringValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>selectionMode</name>
+                <value>
+                    <stringValue>SINGLE_SELECT</stringValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>minRowSelection</name>
+                <value>
+                    <numberValue>1.0</numberValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>tableData</name>
+                <value>
+                    <elementReference>Find_Membership_Form_Submission</elementReference>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>isShowSearchBar</name>
+                <value>
+                    <booleanValue>true</booleanValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>shouldDisplayLabel</name>
+                <value>
+                    <booleanValue>true</booleanValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>maxRowSelection</name>
+                <value>
+                    <numberValue>1.0</numberValue>
+                </value>
+            </inputParameters>
+            <inputParameters>
+                <name>columns</name>
+                <value>
+                    <stringValue>[{&quot;apiName&quot;:&quot;Name&quot;,&quot;guid&quot;:&quot;column-328f&quot;,&quot;editable&quot;:false,&quot;hasCustomHeaderLabel&quot;:false,&quot;customHeaderLabel&quot;:&quot;&quot;,&quot;wrapText&quot;:false,&quot;order&quot;:0,&quot;label&quot;:&quot;Membership Form Submission Name&quot;,&quot;type&quot;:&quot;text&quot;},{&quot;apiName&quot;:&quot;Product_SKU__c&quot;,&quot;guid&quot;:&quot;column-d024&quot;,&quot;editable&quot;:false,&quot;hasCustomHeaderLabel&quot;:false,&quot;customHeaderLabel&quot;:&quot;&quot;,&quot;wrapText&quot;:false,&quot;order&quot;:1,&quot;label&quot;:&quot;Product SKU&quot;,&quot;type&quot;:&quot;text&quot;},{&quot;apiName&quot;:&quot;SalePrice__c&quot;,&quot;guid&quot;:&quot;column-fa70&quot;,&quot;editable&quot;:false,&quot;hasCustomHeaderLabel&quot;:false,&quot;customHeaderLabel&quot;:&quot;&quot;,&quot;wrapText&quot;:false,&quot;order&quot;:2,&quot;label&quot;:&quot;Sale Price&quot;,&quot;type&quot;:&quot;currency&quot;},{&quot;apiName&quot;:&quot;LastName__c&quot;,&quot;guid&quot;:&quot;column-2940&quot;,&quot;editable&quot;:false,&quot;hasCustomHeaderLabel&quot;:false,&quot;customHeaderLabel&quot;:&quot;&quot;,&quot;wrapText&quot;:false,&quot;order&quot;:3,&quot;label&quot;:&quot;Last Name&quot;,&quot;type&quot;:&quot;text&quot;},{&quot;apiName&quot;:&quot;OrganizationName__c&quot;,&quot;guid&quot;:&quot;column-fc66&quot;,&quot;editable&quot;:false,&quot;hasCustomHeaderLabel&quot;:false,&quot;customHeaderLabel&quot;:&quot;&quot;,&quot;wrapText&quot;:false,&quot;order&quot;:4,&quot;label&quot;:&quot;Organization Name&quot;,&quot;type&quot;:&quot;text&quot;}]</stringValue>
+                </value>
+            </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
+            <isRequired>true</isRequired>
+            <storeOutputAutomatically>true</storeOutputAutomatically>
+        </fields>
+        <fields>
+            <name>Select_a_Platform_Event_you_want_to_test</name>
+            <choiceReferences>DPEV_Account_choice</choiceReferences>
+            <choiceReferences>DPEV_Contact_Finder_Choice</choiceReferences>
+            <choiceReferences>DPEV_Find_Campaign_choice</choiceReferences>
+            <choiceReferences>DPEV_Gift_Recipient_Finder_choice</choiceReferences>
+            <choiceReferences>DPEV_Membership_Finder_choice</choiceReferences>
+            <choiceReferences>DPEV_Membership_Renewal_choice</choiceReferences>
+            <choiceReferences>DPEV_Membership_Upgrade_choice</choiceReferences>
+            <choiceReferences>DPEV_Pricebook_Finder_choice</choiceReferences>
+            <choiceReferences>DPEV_Product_Finder_choice</choiceReferences>
+            <choiceReferences>DPEV_Create_Membership_Choice</choiceReferences>
+            <choiceReferences>DPEV_Create_Opportunity_choice</choiceReferences>
+            <choiceReferences>DPEV_Extend_Membership_choice</choiceReferences>
+            <choiceReferences>DPEV_Membership_Downgrade_choice</choiceReferences>
+            <dataType>String</dataType>
+            <fieldText>Select a Platform Event you want to test.</fieldText>
+            <fieldType>RadioButtons</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
+            <isRequired>true</isRequired>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <screens>
+        <name>Membership_Form_Submission_Entry_Screen</name>
+        <label>Membership Form Submission Entry Screen</label>
+        <locationX>1766</locationX>
+        <locationY>134</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>true</allowPause>
+        <connector>
+            <targetReference>Find_Membership_Form_Submission</targetReference>
+        </connector>
+        <fields>
+            <name>Platform_Event_testing_note</name>
+            <fieldText>&lt;p&gt;Before proceeding, please ensure that you have an opportunity product created with a SKU that matches the SKU on the Membership Form Submission record you are troubleshooting or testing.&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
+        </fields>
+        <fields>
+            <name>Membership_Form_Submission_Name</name>
+            <dataType>String</dataType>
+            <defaultValue>
+                <stringValue>MFS-</stringValue>
+            </defaultValue>
+            <fieldText>Membership Form Submission Name</fieldText>
+            <fieldType>InputField</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
+            <isRequired>true</isRequired>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <start>
+        <locationX>1640</locationX>
+        <locationY>0</locationY>
+        <connector>
+            <targetReference>Membership_Form_Submission_Entry_Screen</targetReference>
+        </connector>
+    </start>
+    <status>Draft</status>
+</Flow>


### PR DESCRIPTION
Screen Flow will be brought in as inactive.  Also any new Platform Events will need to be added as new choices. Additional Decision paths and Create Record steps will need to be updated as well.  These will also need to be updated if the naming of the Platform Events is standardized.

# Critical Changes

There were fixes to the automation and platform events made yesterday that are not in this branch, so not all Platform Events will work properly or trigger the expected results.

# Changes

For Testing you can activate the Screen Flow and run it manually, or place it on a page layout once activated.  Alternatively you can review the Screen Flow interface and test it in Flow's Debug mode.

# Issues Closed