### PR TITLE
Implement Unofficial SF Duplicate Matching Rules Component

### DIFF
--- a/force-app/main/default/classes/Duplicate.cls
+++ b/force-app/main/default/classes/Duplicate.cls
@@ -1,0 +1,54 @@
+/**
+ * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
+ * license information below
+
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                 
+This license applies to all code in this LightningFlowComponents repository.
+
+ * 
+**/
+public with sharing class Duplicate implements Comparable{
+    @AuraEnabled
+    public Boolean isDuplicate;
+
+    @AuraEnabled
+    public Id duplicateRecordId;
+
+    @AuraEnabled
+    public String duplicatesObjectType;
+
+    @TestVisible
+    private Double matchConfidence;
+
+    public Duplicate(Boolean isDuplicate, Id duplicateRecordId, String duplicatesObjectType, Double matchConfidence){
+        this.isDuplicate = isDuplicate;
+        this.duplicateRecordId = duplicateRecordId;
+        this.duplicatesObjectType = duplicatesObjectType;
+        this.matchConfidence = matchConfidence;
+    }
+
+    /**
+    * @description Comparable method that sorts the objects in decsending order based on matchConfidence (nulls last)
+    * @param Object compareTo 
+    * @return Integer 
+    **/
+    public Integer compareTo(Object compareTo){
+        Duplicate that = (Duplicate)compareTo;
+        if(this.matchConfidence == that.matchConfidence) return 0;
+        if(this.matchConfidence == null) return 1;
+        if(that.matchConfidence == null) return -1;
+        return (this.matchConfidence < that.matchConfidence) ? 1 : -1;
+    }
+}

--- a/force-app/main/default/classes/Duplicate.cls-meta.xml
+++ b/force-app/main/default/classes/Duplicate.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DuplicateRecordCheck_Invocable.cls
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Invocable.cls
@@ -1,0 +1,85 @@
+/**
+ * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
+ * license information below
+
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                 
+This license applies to all code in this LightningFlowComponents repository.
+
+ * 
+**/
+
+public with sharing class DuplicateRecordCheck_Invocable{
+    /**
+    * @description Contains the Invocable Method that runs the duplicate rules on a particular record(s) to see if a duplicate record(s) exists.
+    * @param List<Input> inputs 
+    * @return List<Duplicate> 
+    **/
+    @InvocableMethod(
+        label='Check for Duplicate Records'
+        description='Runs the duplicate rules on a particular record (or records) to see if a duplicate record (or records) exists.'
+        category='Duplicate Record Check'
+    )
+    public static List<Output> findDuplicates(List<Input> inputs){
+
+        List<sObject> listsObjectsToCheck = new List<sObject>();
+        for(Input input : inputs){
+            if(input.record != null) listsObjectsToCheck.add(input.record);
+            if(input.records != null) listsObjectsToCheck.addAll(input.records);
+        }
+
+        List<Duplicate> duplicates = DuplicateRecordCheck_Util.findDuplicates(listsObjectsToCheck);
+
+        List<Output> outputs = new List<Output>();
+        for(Input input : inputs){
+            Output output = new Output();
+            if(input.record != null){
+                output.duplicate = duplicates.remove(0);
+            }
+
+            if(input.records != null){
+                output.duplicates = new List<Duplicate>();
+                for(sObject record : input.records){
+                    output.duplicates.add(duplicates.remove(0));
+                }
+            }
+
+            outputs.add(output);
+        }
+
+        return outputs;
+    }
+
+    /**
+    * @description Wrapper class for invocable inputs
+    **/
+    public class Input{
+        @InvocableVariable(label='Single Record to Check for Duplicates')
+        public sObject record;
+
+        @InvocableVariable(label='Collection of Records to Check for Duplicates')
+        public List<sObject> records;
+    }
+
+    /**
+    * @description Wrapper class for invocable outputs
+    **/
+    public class Output{
+        @InvocableVariable(label='Duplicate Result from Single Record')
+        public Duplicate duplicate;
+
+        @InvocableVariable(label='Duplicate Results from Collection of Records')
+        public List<Duplicate> duplicates;
+    }
+}

--- a/force-app/main/default/classes/DuplicateRecordCheck_Invocable.cls-meta.xml
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Invocable.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DuplicateRecordCheck_Test.cls
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Test.cls
@@ -1,0 +1,169 @@
+/**
+ * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
+ * license information below
+
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                 
+This license applies to all code in this LightningFlowComponents repository.
+
+ * 
+**/
+@isTest
+public class DuplicateRecordCheck_Test{
+    
+    private static final Integer NUMBER_OF_LOOPS = 51; // This should be at least 51 for full test coverage.
+    private static final Id MATCHING_ID = '001000000000RGMRGM';
+    private static final String OBJECT_NAME = 'Account';
+    private static Boolean returnDuplicates = true;
+
+    @isTest
+    public static void Duplicate_Test(){
+        FindDuplicatesFactory.stubFactory = new MockFindDuplicatesFactory();
+        
+        List<DuplicateRecordCheck_Invocable.Input> inputs = new List<DuplicateRecordCheck_Invocable.Input>();
+        for(Integer i = 1; i <= NUMBER_OF_LOOPS; i++){
+            DuplicateRecordCheck_Invocable.Input input = new DuplicateRecordCheck_Invocable.Input();
+            input.record = new Account();
+            input.records = new List<sObject>{new Account()};
+            inputs.add(input);
+        }
+
+        System.Test.startTest();
+        	List<DuplicateRecordCheck_Invocable.Output> outputs = DuplicateRecordCheck_Invocable.findDuplicates(inputs);
+        System.Test.stopTest();
+
+        System.assertEquals(NUMBER_OF_LOOPS, outputs.size());
+        for(DuplicateRecordCheck_Invocable.Output output : outputs){
+            System.assertEquals(TRUE, output.Duplicate.isDuplicate);
+            System.assertEquals(MATCHING_ID, output.Duplicate.duplicateRecordId);
+            System.assertEquals(OBJECT_NAME, output.Duplicate.duplicatesObjectType);
+
+            for(Duplicate duplicate : output.duplicates){
+                System.assertEquals(TRUE, duplicate.isDuplicate);
+                System.assertEquals(MATCHING_ID, duplicate.duplicateRecordId);
+                System.assertEquals(OBJECT_NAME, duplicate.duplicatesObjectType);
+            }
+        }
+    }
+    
+    @isTest
+    public static void Non_Duplicate_Test(){
+        returnDuplicates = false;
+        FindDuplicatesFactory.stubFactory = new MockFindDuplicatesFactory();
+
+        List<DuplicateRecordCheck_Invocable.Input> inputs = new List<DuplicateRecordCheck_Invocable.Input>();
+        for(Integer i = 1; i <= NUMBER_OF_LOOPS; i++){
+	        DuplicateRecordCheck_Invocable.Input input = new DuplicateRecordCheck_Invocable.Input();
+            input.record = new Account();
+            inputs.add(input);
+        }
+
+        System.Test.startTest();
+        	List<DuplicateRecordCheck_Invocable.Output> outputs = DuplicateRecordCheck_Invocable.findDuplicates(inputs);
+        System.Test.stopTest();
+        
+        System.assertEquals(NUMBER_OF_LOOPS, outputs.size());
+        for(DuplicateRecordCheck_Invocable.Output output : outputs){
+            System.assertEquals(FALSE, output.Duplicate.isDuplicate);
+            System.assertEquals(NULL, output.Duplicate.duplicateRecordId);
+            System.assertEquals(NULL, output.Duplicate.duplicatesObjectType);
+        }
+    }
+
+    @IsTest
+    public static void Factory_Test(){
+        try {
+            List<sObject> records = new List<sObject>{new Account()};
+            
+            System.Test.startTest();
+                FindDuplicatesFactory factory = FindDuplicatesFactory.getFactory();
+                FindDuplicates findDuplicates = factory.getFindDuplicates();
+                List<FindDuplicates.FindDuplicatesResult> duplicates = findDuplicates.findDuplicates(records);
+            System.Test.stopTest();
+
+            system.assertEquals(records.size(), duplicates.size());
+        } catch (Exception ex) {
+            system.debug(ex);
+        }
+    }
+
+    @isTest
+    public static void Comparable_Test(){
+        List<Duplicate> duplicates = new List<Duplicate>();
+        for(Integer i = 1; i <= NUMBER_OF_LOOPS; i++){
+            if(i == 1){
+                duplicates.add(new Duplicate(FALSE,null,null,null));
+            } else {
+                duplicates.add(new Duplicate(TRUE,null,null,i));
+            }
+        }
+        duplicates.sort();
+        
+        Integer counter = NUMBER_OF_LOOPS;
+        for(Duplicate duplicate : duplicates){
+            if(counter == 1){
+                system.assertEquals(null, duplicate.matchConfidence);
+            } else {
+                system.assertEquals(counter, duplicate.matchConfidence);
+            }
+            counter--;
+        }
+    }
+
+    private class MockFindDuplicatesFactory extends FindDuplicatesFactory{
+        MockFindDuplicatesFactory(){
+            super();
+        }
+
+        public override FindDuplicates getFindDuplicates(){
+            if(returnDuplicates){
+                return new Dupe();
+            } else {
+                return new NotADupe();
+            }
+        }
+    }
+
+    private class Dupe extends FindDuplicates{
+        
+        public override List<FindDuplicatesResult> findDuplicates(List<SObject> records){
+            List<FindDuplicatesResult> results = new List<FindDuplicatesResult>();
+
+            for(Integer i = 1; i <= records.size(); i++){
+                List<MatchRecord> matchRecords = new List<MatchRecord>{new MatchRecord((Id)MATCHING_ID,(Double)100.0)};
+                List<MatchResult> matchResults = new List<MatchResult>{new MatchResult(matchRecords)};
+                List<DuplicateResult> duplicateResults = new List<DuplicateResult>{new DuplicateResult(matchResults)};
+                results.add(new FindDuplicatesResult(duplicateResults));
+            }
+
+            return results;
+        }
+        
+    }
+
+    private class NotADupe extends FindDuplicates{
+        public override List<FindDuplicatesResult> findDuplicates(List<SObject> records){
+            List<FindDuplicatesResult> results = new List<FindDuplicatesResult>();
+
+            for(Integer i = 1; i <= records.size(); i++){
+                List<MatchRecord> matchRecords = new List<MatchRecord>();
+                List<MatchResult> matchResults = new List<MatchResult>{new MatchResult(matchRecords)};
+                List<DuplicateResult> duplicateResults = new List<DuplicateResult>{new DuplicateResult(matchResults)};
+                results.add(new FindDuplicatesResult(duplicateResults));
+            }
+
+            return results;
+        }
+    }
+}

--- a/force-app/main/default/classes/DuplicateRecordCheck_Test.cls-meta.xml
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Test.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DuplicateRecordCheck_Util.cls
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Util.cls
@@ -1,0 +1,89 @@
+/**
+ * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
+ * license information below
+
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                 
+This license applies to all code in this LightningFlowComponents repository.
+
+ * 
+**/
+public with sharing class DuplicateRecordCheck_Util {
+    private final FindDuplicates findDuplicates;
+
+    private DuplicateRecordCheck_Util(){
+        FindDuplicatesFactory factory = FindDuplicatesFactory.getFactory();
+        this.findDuplicates = factory.getFindDuplicates();
+    }
+
+    private static DuplicateRecordCheck_Util self = new DuplicateRecordCheck_Util();
+
+    /**
+    * @description Runs the duplicate rules on a particular record(s) to see if a duplicate record(s) exists.
+    * @param List<Input> inputs 
+    * @return List<Duplicate> 
+    **/
+    public static List<Duplicate> findDuplicates(List<sObject> records){
+        // The documentation states that the max input array for the findDuplicates method is 50.
+        // We are instantiating a new list to house the results in case we have to execute the method multiple times.
+        List<FindDuplicates.FindDuplicatesResult> results = new List<FindDuplicates.FindDuplicatesResult>();
+        List<sObject> listsObjectsToCheck = new List<sObject>();
+        for(sObject record : records){
+            listsObjectsToCheck.add(record);
+            
+            // Check to see if the list size equals 50.
+            // If so, execute the findDuplicates method and clear the list.
+            if(listsObjectsToCheck.size() == 50){
+                results.addAll(self.findDuplicates.findDuplicates(listsObjectsToCheck));
+                listsObjectsToCheck.clear();
+            }
+        }
+
+        // Execute the findDuplicates method a final time.
+        if(!listsObjectsToCheck.isEmpty()){
+            results.addAll(self.findDuplicates.findDuplicates(listsObjectsToCheck));
+        }
+
+        // The mapIndexToDuplicate is a map where the key is the index and the value is the best Duplicate result (if any exist).
+        Integer index = 0;
+        Map<Integer,Duplicate> mapIndexToDuplicate = new Map<Integer,Duplicate>();
+        for(FindDuplicates.FindDuplicatesResult find : results) {
+            // Add the default Duplicate to the map, which is simply Duplicate.isDuplicate = FALSE.
+            mapIndexToDuplicate.put(index,new Duplicate(FALSE,null,null,null));
+            for(FindDuplicates.DuplicateResult result : find.getDuplicateResults) {
+                // result has a bunch of information about the Duplicate Rule being applied.
+                for(FindDuplicates.MatchResult match : result.getMatchResults) {
+                    // match has a bunch of information about the Matching Rule being applied.
+                    
+                    // Instantiate a new list of Duplicates with the Duplicate from the map.
+                    List<Duplicate> duplicates = new List<Duplicate>{mapIndexToDuplicate.get(index)};
+                    for(FindDuplicates.MatchRecord record : match.getMatchRecords) {
+                        Id recordId = record.getRecordId;
+                        Double matchConfidence = record.getMatchConfidence == null ? 0 : record.getMatchConfidence;
+                        String sObjectType = recordId.getSObjectType().getDescribe().getName();
+                        duplicates.add(new Duplicate(TRUE,recordId,sObjectType,matchConfidence));
+                    }
+                    
+                    // The Duplicate object implements the Comparable interface, so we are sorting the list in a specific way.
+                    // The best Duplicate is the first object from the list because it has the highest matchConfidence.
+                    duplicates.sort();
+                    mapIndexToDuplicate.put(index,duplicates.remove(0));
+                }
+            }
+            index++;
+        }
+
+        return mapIndexToDuplicate.values();
+    }
+}

--- a/force-app/main/default/classes/DuplicateRecordCheck_Util.cls-meta.xml
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Util.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/FindDuplicates.cls
+++ b/force-app/main/default/classes/FindDuplicates.cls
@@ -1,0 +1,105 @@
+/**
+ * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
+ * license information below
+
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                 
+This license applies to all code in this LightningFlowComponents repository.
+
+ * 
+**/
+public with sharing virtual class FindDuplicates {
+    
+    /**
+    * @description Mimics the shape of the Datacloud FindDuplicates method, and instantiates custom classes so that the results can be more easily processed.
+    * @param List<SObject> records 
+    * @return List<FindDuplicatesResult>
+    **/
+    public virtual List<FindDuplicatesResult> findDuplicates(List<SObject> records){
+        try {
+            List<Datacloud.FindDuplicatesResult> findDuplicateResults = Datacloud.FindDuplicates.findDuplicates(records);
+            
+            List<FindDuplicatesResult> results = new List<FindDuplicatesResult>();
+            for(Datacloud.FindDuplicatesResult find : findDuplicateResults) {
+                List<DuplicateResult> duplicateResults = new List<DuplicateResult>();
+                for(Datacloud.DuplicateResult result : find.getDuplicateResults()) {
+                    List<MatchResult> matchResults = new List<MatchResult>();
+                    for(Datacloud.MatchResult match : result.getMatchResults()) {
+                        List<MatchRecord> matchRecords = new List<MatchRecord>();
+                        for(Datacloud.MatchRecord record : match.getMatchRecords()) {
+                            matchRecords.add(new MatchRecord(record.getRecord().Id,record.getMatchConfidence()));
+                        }
+                        matchResults.add(new MatchResult(matchRecords));
+                    }
+                    duplicateResults.add(new DuplicateResult(matchResults));
+                }
+                results.add(new FindDuplicatesResult(duplicateResults));
+            }
+            return results;
+        } catch (Exception ex) {
+            throw new FindDuplicatesException(ex.getMessage());
+        }
+    }
+
+    /**
+    * @description Wrapper class for FindDuplicatesResult to mimic the shape of https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_Datacloud_FindDuplicatesResult.htm
+    **/
+    public class FindDuplicatesResult{
+        public List<DuplicateResult> getDuplicateResults;
+
+        public FindDuplicatesResult(List<DuplicateResult> results) {
+            this.getDuplicateResults = results;
+        }
+    }
+
+    /**
+    * @description Wrapper class for DuplicateResult to mimic the shape of https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_Datacloud_DuplicateResult.htm
+    **/
+    public class DuplicateResult{
+        public List<MatchResult> getMatchResults;
+
+        public DuplicateResult(List<MatchResult> matches){
+            this.getMatchResults = matches;
+        }
+    }
+
+    /**
+    * @description Wrapper class for MatchResult to mimic the shape of https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_Datacloud_MatchResult.htm
+    **/
+    public class MatchResult{
+        public List<MatchRecord> getMatchRecords;
+
+        public MatchResult(List<MatchRecord> records){
+            this.getMatchRecords = records;
+        }
+    }
+
+    /**
+    * @description Wrapper class for MatchResult to mimic the shape of https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_Datacloud_MatchRecord.htm
+    **/
+    public class MatchRecord{
+        public Id getRecordId;
+        public Double getMatchConfidence;
+
+        public MatchRecord(Id recordId, Double matchConfidence){
+            this.getRecordId = recordId;
+            this.getMatchConfidence = matchConfidence;
+        }
+    }
+
+    /**
+    * @description So we can throw exceptions
+    **/
+    public class FindDuplicatesException extends Exception{}
+}

--- a/force-app/main/default/classes/FindDuplicates.cls-meta.xml
+++ b/force-app/main/default/classes/FindDuplicates.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/FindDuplicatesFactory.cls
+++ b/force-app/main/default/classes/FindDuplicatesFactory.cls
@@ -1,0 +1,42 @@
+/**
+ * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
+ * license information below
+
+Copyright (c) 2018, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                 
+This license applies to all code in this LightningFlowComponents repository.
+
+ * 
+**/
+public with sharing virtual class FindDuplicatesFactory {
+    @TestVisible
+    private static FindDuplicatesFactory stubFactory;
+    private static FindDuplicatesFactory factory;
+
+    protected FindDuplicatesFactory() {}
+
+    public static FindDuplicatesFactory getFactory() {
+        if (stubFactory != null) {
+            return stubFactory;
+        } else if (factory == null) {
+            factory = new FindDuplicatesFactory();
+        }
+
+        return factory;
+    }
+
+    public virtual FindDuplicates getFindDuplicates(){
+        return new FindDuplicates();
+    }
+}

--- a/force-app/main/default/classes/FindDuplicatesFactory.cls-meta.xml
+++ b/force-app/main/default/classes/FindDuplicatesFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
This component can be incorporated into existing flows. The code could also be modified if we want to add additional features (eg. returning all potential matches instead of just the best match, etc).

# Critical Changes

# Changes

Added code from an existing Unofficial SF flow component. The component takes a single or collection of records as an input and outputs an apexdefined object that contains an isduplicate boolean flag and the recordId of the best duplicate match if there are one or more duplicates.
Full documentation here: https://unofficialsf.com/from-ryan-mercer-a-better-way-to-check-for-duplicate-records-in-flow/

# Issues Closed