### PR TITLE
Implement Duplicate Matching Rules in contact and account flows

### DIFF
--- a/force-app/main/default/classes/DuplicateRecordCheck_Invocable.cls
+++ b/force-app/main/default/classes/DuplicateRecordCheck_Invocable.cls
@@ -1,6 +1,6 @@
 /**
  * Copied from unOfficial Salesforce: https://github.com/UnofficialSF/LightningFlowComponents
- * license information below
+ * license information below, modified to better handle situations where duplicate rules are inactive
 
 Copyright (c) 2018, Salesforce.com, Inc.
 All rights reserved.
@@ -22,7 +22,7 @@ This license applies to all code in this LightningFlowComponents repository.
 
 public with sharing class DuplicateRecordCheck_Invocable{
     /**
-    * @description Contains the Invocable Method that runs the duplicate rules on a particular record(s) to see if a duplicate record(s) exists.
+    * @description Contains the Invocable Method that runs the duplicate rules on a particular record(s) to see if a duplicate record(s) exists. If there are no active duplicate rules, returns the inputted records.
     * @param List<Input> inputs 
     * @return List<Duplicate> 
     **/
@@ -32,32 +32,41 @@ public with sharing class DuplicateRecordCheck_Invocable{
         category='Duplicate Record Check'
     )
     public static List<Output> findDuplicates(List<Input> inputs){
-
-        List<sObject> listsObjectsToCheck = new List<sObject>();
-        for(Input input : inputs){
-            if(input.record != null) listsObjectsToCheck.add(input.record);
-            if(input.records != null) listsObjectsToCheck.addAll(input.records);
-        }
-
-        List<Duplicate> duplicates = DuplicateRecordCheck_Util.findDuplicates(listsObjectsToCheck);
-
         List<Output> outputs = new List<Output>();
-        for(Input input : inputs){
+        
+        //process each input/request separately
+        for (Input input : inputs) {
             Output output = new Output();
-            if(input.record != null){
-                output.duplicate = duplicates.remove(0);
+            
+            List<sObject> listsObjectsToCheck = new List<sObject>();
+            if(input.record != null) {
+                listsObjectsToCheck.add(input.record);
             }
-
-            if(input.records != null){
-                output.duplicates = new List<Duplicate>();
-                for(sObject record : input.records){
-                    output.duplicates.add(duplicates.remove(0));
+            if(input.records != null) {
+                listsObjectsToCheck.addAll(input.records);
+            }
+            
+            try {
+                List<Duplicate> duplicates = DuplicateRecordCheck_Util.findDuplicates(listsObjectsToCheck);
+                
+                if(input.record != null){
+                    output.duplicate = duplicates.remove(0);
                 }
+                if(input.records != null){
+                    output.duplicates = new List<Duplicate>();
+                    for(sObject record : input.records){
+                        output.duplicates.add(duplicates.remove(0));
+                    }
+                }
+                
+                output.isSuccess = true;
+            } catch (Exception e) {
+                output.isSuccess = false;
             }
-
+            
             outputs.add(output);
         }
-
+        
         return outputs;
     }
 
@@ -81,5 +90,8 @@ public with sharing class DuplicateRecordCheck_Invocable{
 
         @InvocableVariable(label='Duplicate Results from Collection of Records')
         public List<Duplicate> duplicates;
+        
+        @InvocableVariable(label='Did duplicate search complete successfully?')
+        public Boolean isSuccess;
     }
 }

--- a/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
@@ -60,6 +60,29 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Add_Log_Message_Found_Account</name>
+        <label>Add Log Message - Found Account</label>
+        <locationX>578</locationX>
+        <locationY>926</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>Existing Account Matched; </stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Pass</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>set_MFS_Success_Info_Found_Account</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Add_Log_Message_No_Account</name>
         <label>Add Log Message - No Account</label>
         <locationX>50</locationX>
@@ -110,31 +133,15 @@
                 <elementReference>StaticFlowName</elementReference>
             </value>
         </assignmentItems>
-        <connector>
-            <targetReference>Get_Membership_Form_Submission</targetReference>
-        </connector>
-    </assignments>
-    <assignments>
-        <name>set_Log_Message_Found_Account</name>
-        <label>set Log Message - Found Account</label>
-        <locationX>578</locationX>
-        <locationY>926</locationY>
         <assignmentItems>
             <assignToReference>soLogRecord.Log_Message__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <stringValue>Existing Account Matched</stringValue>
-            </value>
-        </assignmentItems>
-        <assignmentItems>
-            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
-            <operator>Assign</operator>
-            <value>
-                <stringValue>Pass</stringValue>
+                <stringValue></stringValue>
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>set_MFS_Success_Info_Found_Account</targetReference>
+            <targetReference>Get_Membership_Form_Submission</targetReference>
         </connector>
     </assignments>
     <assignments>
@@ -307,7 +314,7 @@
         <locationX>314</locationX>
         <locationY>818</locationY>
         <defaultConnector>
-            <targetReference>set_Log_Message_Found_Account</targetReference>
+            <targetReference>Add_Log_Message_Found_Account</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Match Found</defaultConnectorLabel>
         <rules>

--- a/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
@@ -110,6 +110,13 @@
                 <stringValue>Membership Form Submission Updated</stringValue>
             </value>
         </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Pass</stringValue>
+            </value>
+        </assignmentItems>
         <connector>
             <targetReference>Insert_Success_Log</targetReference>
         </connector>

--- a/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
@@ -1,11 +1,148 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <actionCalls>
+        <name>Check_for_Account_Matches</name>
+        <label>Check for Account Matches</label>
+        <locationX>314</locationX>
+        <locationY>710</locationY>
+        <actionName>DuplicateRecordCheck_Invocable</actionName>
+        <actionType>apex</actionType>
+        <connector>
+            <targetReference>Found_Matching_Account</targetReference>
+        </connector>
+        <dataTypeMappings>
+            <typeName>T__record</typeName>
+            <typeValue>Account</typeValue>
+        </dataTypeMappings>
+        <dataTypeMappings>
+            <typeName>T__records</typeName>
+            <typeValue>Account</typeValue>
+        </dataTypeMappings>
+        <faultConnector>
+            <isGoTo>true</isGoTo>
+            <targetReference>set_Error_Log_Values</targetReference>
+        </faultConnector>
+        <flowTransactionModel>CurrentTransaction</flowTransactionModel>
+        <inputParameters>
+            <name>record</name>
+            <value>
+                <elementReference>soAccount</elementReference>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>records</name>
+        </inputParameters>
+        <nameSegment>DuplicateRecordCheck_Invocable</nameSegment>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </actionCalls>
     <apiVersion>49.0</apiVersion>
     <assignments>
-        <name>Update_MFS_Error</name>
-        <label>Update MFS - Error</label>
-        <locationX>314</locationX>
-        <locationY>818</locationY>
+        <name>Add_Log_Message_Create_Account</name>
+        <label>Add Log Message - Create Account</label>
+        <locationX>50</locationX>
+        <locationY>1142</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>New account created; </stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Pass</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>set_MFS_Success_Info_Create_Account</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>Add_Log_Message_No_Account</name>
+        <label>Add Log Message - No Account</label>
+        <locationX>50</locationX>
+        <locationY>926</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>No matching account record found; </stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Create_Account</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_Error_Log_Values</name>
+        <label>set Error Log Values</label>
+        <locationX>1634</locationX>
+        <locationY>386</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Error</stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>Error: {!$Flow.FaultMessage}</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>insert_Error_Log</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_Initial_Log_Values</name>
+        <label>set Initial Log Values</label>
+        <locationX>710</locationX>
+        <locationY>170</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Flow_Name__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>StaticFlowName</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Get_Membership_Form_Submission</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_Log_Message_Found_Account</name>
+        <label>set Log Message - Found Account</label>
+        <locationX>578</locationX>
+        <locationY>926</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Existing Account Matched</stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Pass</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>set_MFS_Success_Info_Found_Account</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>update MFS status to failed andset the failure message</description>
+        <name>set_MFS_Error_Values</name>
+        <label>set MFS Error Values</label>
+        <locationX>1634</locationX>
+        <locationY>602</locationY>
         <assignmentItems>
             <assignToReference>Get_Membership_Form_Submission.Status__c</assignToReference>
             <operator>Assign</operator>
@@ -17,35 +154,51 @@
             <assignToReference>Get_Membership_Form_Submission.Failure_Information__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <stringValue>Failed to Create Account</stringValue>
+                <elementReference>varMFSFailureMessage</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>update_MFS</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_MFS_Failure_Message</name>
+        <label>set MFS Failure Message</label>
+        <locationX>314</locationX>
+        <locationY>1142</locationY>
+        <assignmentItems>
+            <assignToReference>varMFSFailureMessage</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Failed to create new account record</stringValue>
             </value>
         </assignmentItems>
         <connector>
             <isGoTo>true</isGoTo>
-            <targetReference>Update_Membership_Form_Submission</targetReference>
+            <targetReference>set_Error_Log_Values</targetReference>
         </connector>
     </assignments>
     <assignments>
-        <name>Update_MFS_Skip</name>
-        <label>Update MFS - Skip</label>
-        <locationX>1106</locationX>
+        <name>set_MFS_Id_in_Log</name>
+        <label>set MFS Id in Log</label>
+        <locationX>710</locationX>
         <locationY>386</locationY>
         <assignmentItems>
-            <assignToReference>Get_Membership_Form_Submission.Account_Import_Status__c</assignToReference>
+            <assignToReference>soLogRecord.Membership_Form_Submission__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <stringValue>Skipped</stringValue>
+                <elementReference>Get_Membership_Form_Submission.Id</elementReference>
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Update_Membership_Form_Submission</targetReference>
+            <targetReference>Is_account_name_populated</targetReference>
         </connector>
     </assignments>
     <assignments>
-        <name>Update_MFS_Success</name>
-        <label>Update MFS - Success</label>
+        <name>set_MFS_Success_Info_Create_Account</name>
+        <label>set MFS Success Info - Create Account</label>
         <locationX>50</locationX>
-        <locationY>818</locationY>
+        <locationY>1250</locationY>
         <assignmentItems>
             <assignToReference>Get_Membership_Form_Submission.Account_Import_Status__c</assignToReference>
             <operator>Assign</operator>
@@ -65,22 +218,83 @@
         </connector>
     </assignments>
     <assignments>
-        <name>Update_MFS_Success_found</name>
-        <label>Update MFS - Success</label>
+        <name>set_MFS_Success_Info_Found_Account</name>
+        <label>set MFS Success Info - Found Account</label>
         <locationX>578</locationX>
-        <locationY>710</locationY>
+        <locationY>1034</locationY>
         <assignmentItems>
             <assignToReference>Get_Membership_Form_Submission.Account_Import_Status__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <stringValue>Imported</stringValue>
+                <stringValue>Matched</stringValue>
             </value>
         </assignmentItems>
         <assignmentItems>
             <assignToReference>Get_Membership_Form_Submission.Account__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <elementReference>Get_Account.Id</elementReference>
+                <elementReference>Check_for_Account_Matches.duplicate.duplicateRecordId</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Update_Membership_Form_Submission</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_Temp_Account</name>
+        <label>set Temp Account</label>
+        <locationX>314</locationX>
+        <locationY>602</locationY>
+        <assignmentItems>
+            <assignToReference>soAccount.Name</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Get_Membership_Form_Submission.OrganizationName__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soAccount.BillingStreet</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Get_Membership_Form_Submission.BillingStreet__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soAccount.BillingState</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Get_Membership_Form_Submission.BillingState__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soAccount.BillingCity</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Get_Membership_Form_Submission.BillingCity__c</elementReference>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soAccount.BillingPostalCode</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Get_Membership_Form_Submission.BillingZip__c</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Check_for_Account_Matches</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <description>Log that Account find/create action was skipped</description>
+        <name>Update_MFS_Skipped</name>
+        <label>Update MFS - Skipped</label>
+        <locationX>1106</locationX>
+        <locationY>602</locationY>
+        <assignmentItems>
+            <assignToReference>Get_Membership_Form_Submission.Account_Import_Status__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Skipped</stringValue>
             </value>
         </assignmentItems>
         <connector>
@@ -88,12 +302,44 @@
         </connector>
     </assignments>
     <decisions>
+        <name>Found_Matching_Account</name>
+        <label>Found Matching Account?</label>
+        <locationX>314</locationX>
+        <locationY>818</locationY>
+        <defaultConnector>
+            <targetReference>set_Log_Message_Found_Account</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>Match Found</defaultConnectorLabel>
+        <rules>
+            <name>No_Matching_Account</name>
+            <conditionLogic>or</conditionLogic>
+            <conditions>
+                <leftValueReference>Check_for_Account_Matches.isSuccess</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Check_for_Account_Matches.duplicate.isDuplicate</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Add_Log_Message_No_Account</targetReference>
+            </connector>
+            <label>No Matching Account</label>
+        </rules>
+    </decisions>
+    <decisions>
         <name>Is_account_name_populated</name>
         <label>Is account name populated?</label>
         <locationX>710</locationX>
-        <locationY>278</locationY>
+        <locationY>494</locationY>
         <defaultConnector>
-            <targetReference>Update_MFS_Skip</targetReference>
+            <targetReference>Update_MFS_Skipped</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>No</defaultConnectorLabel>
         <rules>
@@ -107,37 +353,12 @@
                 </rightValue>
             </conditions>
             <connector>
-                <targetReference>Get_Account</targetReference>
+                <targetReference>set_Temp_Account</targetReference>
             </connector>
             <label>Yes</label>
         </rules>
     </decisions>
-    <decisions>
-        <name>Is_Account_Null</name>
-        <label>Is Account Null</label>
-        <locationX>314</locationX>
-        <locationY>494</locationY>
-        <defaultConnector>
-            <targetReference>Create_Membership_Essentials_Log_Pass</targetReference>
-        </defaultConnector>
-        <defaultConnectorLabel>No, Find</defaultConnectorLabel>
-        <rules>
-            <name>Yes_Create</name>
-            <conditionLogic>and</conditionLogic>
-            <conditions>
-                <leftValueReference>Get_Account</leftValueReference>
-                <operator>IsNull</operator>
-                <rightValue>
-                    <booleanValue>true</booleanValue>
-                </rightValue>
-            </conditions>
-            <connector>
-                <targetReference>Create_Account</targetReference>
-            </connector>
-            <label>Yes, Create</label>
-        </rules>
-    </decisions>
-    <description>Create or find account associated with Membership Form Submission</description>
+    <description>If the Organization Name is populated, attempts to find a matching Account using active duplicate rules. If duplicate rules are inactive or no match is found, creates a new Account.</description>
     <environments>Default</environments>
     <interviewLabel>DPEV Listener - {!$Flow.CurrentDateTime}</interviewLabel>
     <label>DPEV Listener - Create or Find Account</label>
@@ -164,12 +385,12 @@
         <name>Create_Account</name>
         <label>Create Account</label>
         <locationX>50</locationX>
-        <locationY>602</locationY>
+        <locationY>1034</locationY>
         <connector>
-            <targetReference>Create_Membership_Essentials_Log_Pass1</targetReference>
+            <targetReference>Add_Log_Message_Create_Account</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Create_Create_Account_Membership_Essentials_Log</targetReference>
+            <targetReference>set_MFS_Failure_Message</targetReference>
         </faultConnector>
         <inputAssignments>
             <field>Name</field>
@@ -181,205 +402,10 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
     <recordCreates>
-        <name>Create_Create_Account_Membership_Essentials_Log</name>
-        <label>Create &quot;Create Account&quot; Membership Essentials Log</label>
-        <locationX>314</locationX>
-        <locationY>710</locationY>
-        <connector>
-            <targetReference>Update_MFS_Error</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <elementReference>$Flow.FaultMessage</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_Membership_Form_Submission.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Get_Account_Membership_Essentials_Log</name>
-        <label>Create &quot;Get Account&quot; Membership Essentials Log</label>
-        <locationX>842</locationX>
-        <locationY>494</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <elementReference>$Flow.FaultMessage</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_Membership_Form_Submission.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Initial_Membership_Essentials_Log</name>
-        <label>Create Initial Membership Essentials Log</label>
-        <locationX>1634</locationX>
-        <locationY>278</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>Platform event triggered. {!$Flow.FaultMessage}</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Membership_Essentials_Log_Pass</name>
-        <label>Create Membership Essentials Log - Pass</label>
-        <locationX>578</locationX>
-        <locationY>602</locationY>
-        <connector>
-            <targetReference>Update_MFS_Success_found</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>Account Found</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Pass</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_Membership_Form_Submission.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Membership_Essentials_Log_Pass1</name>
-        <label>Create Membership Essentials Log - Pass</label>
-        <locationX>50</locationX>
-        <locationY>710</locationY>
-        <connector>
-            <targetReference>Update_MFS_Success</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>Account Created</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Pass</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_Membership_Form_Submission.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Membership_Essentials_Log_Pass2</name>
-        <label>Create Membership Essentials Log - Pass</label>
-        <locationX>710</locationX>
-        <locationY>1292</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>Membership Form Submission has been updated</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Pass</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_Membership_Form_Submission.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Update_MFS_Membership_Essentials_Log</name>
-        <label>Create &quot;Update MFS&quot; Membership Essentials Log</label>
+        <name>Create_MFS_Update_Error_Log</name>
+        <label>Create MFS Update Error Log</label>
         <locationX>1370</locationX>
-        <locationY>1292</locationY>
+        <locationY>1634</locationY>
         <inputAssignments>
             <field>Flow_Name__c</field>
             <value>
@@ -407,41 +433,34 @@
         <object>Membership_Essentials_Event_Log__c</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
-    <recordLookups>
-        <name>Get_Account</name>
-        <label>Get Account</label>
-        <locationX>314</locationX>
-        <locationY>386</locationY>
-        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+    <recordCreates>
+        <name>insert_Error_Log</name>
+        <label>insert Error Log</label>
+        <locationX>1634</locationX>
+        <locationY>494</locationY>
         <connector>
-            <targetReference>Is_Account_Null</targetReference>
+            <targetReference>set_MFS_Error_Values</targetReference>
         </connector>
-        <faultConnector>
-            <targetReference>Create_Get_Account_Membership_Essentials_Log</targetReference>
-        </faultConnector>
-        <filterLogic>and</filterLogic>
-        <filters>
-            <field>Name</field>
-            <operator>EqualTo</operator>
-            <value>
-                <elementReference>Get_Membership_Form_Submission.OrganizationName__c</elementReference>
-            </value>
-        </filters>
-        <getFirstRecordOnly>true</getFirstRecordOnly>
-        <object>Account</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordLookups>
+        <inputReference>soLogRecord</inputReference>
+    </recordCreates>
+    <recordCreates>
+        <name>Insert_Success_Log</name>
+        <label>Insert Success Log</label>
+        <locationX>710</locationX>
+        <locationY>1634</locationY>
+        <inputReference>soLogRecord</inputReference>
+    </recordCreates>
     <recordLookups>
         <name>Get_Membership_Form_Submission</name>
         <label>Get Membership Form Submission</label>
         <locationX>710</locationX>
-        <locationY>170</locationY>
+        <locationY>278</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>Is_account_name_populated</targetReference>
+            <targetReference>set_MFS_Id_in_Log</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Create_Initial_Membership_Essentials_Log</targetReference>
+            <targetReference>set_Error_Log_Values</targetReference>
         </faultConnector>
         <filterLogic>and</filterLogic>
         <filters>
@@ -459,12 +478,24 @@
         <name>Update_Membership_Form_Submission</name>
         <label>Update Membership Form Submission</label>
         <locationX>710</locationX>
-        <locationY>1184</locationY>
+        <locationY>1526</locationY>
         <connector>
-            <targetReference>Create_Membership_Essentials_Log_Pass2</targetReference>
+            <targetReference>Insert_Success_Log</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Create_Update_MFS_Membership_Essentials_Log</targetReference>
+            <targetReference>Create_MFS_Update_Error_Log</targetReference>
+        </faultConnector>
+        <inputReference>Get_Membership_Form_Submission</inputReference>
+    </recordUpdates>
+    <recordUpdates>
+        <description>Update MFS with the error values</description>
+        <name>update_MFS</name>
+        <label>update MFS</label>
+        <locationX>1634</locationX>
+        <locationY>710</locationY>
+        <faultConnector>
+            <isGoTo>true</isGoTo>
+            <targetReference>Create_MFS_Update_Error_Log</targetReference>
         </faultConnector>
         <inputReference>Get_Membership_Form_Submission</inputReference>
     </recordUpdates>
@@ -472,12 +503,28 @@
         <locationX>584</locationX>
         <locationY>0</locationY>
         <connector>
-            <targetReference>Get_Membership_Form_Submission</targetReference>
+            <targetReference>set_Initial_Log_Values</targetReference>
         </connector>
         <object>DPEV_Account__e</object>
         <triggerType>PlatformEvent</triggerType>
     </start>
     <status>Active</status>
+    <variables>
+        <name>soAccount</name>
+        <dataType>SObject</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Account</objectType>
+    </variables>
+    <variables>
+        <name>soLogRecord</name>
+        <dataType>SObject</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Membership_Essentials_Event_Log__c</objectType>
+    </variables>
     <variables>
         <name>StaticFlowName</name>
         <dataType>String</dataType>
@@ -487,5 +534,12 @@
         <value>
             <stringValue>DPEV Listener - Create or Find Account</stringValue>
         </value>
+    </variables>
+    <variables>
+        <name>varMFSFailureMessage</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
     </variables>
 </Flow>

--- a/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
@@ -99,6 +99,22 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Add_Log_Message_Updated_MFS</name>
+        <label>Add Log Message - Updated MFS</label>
+        <locationX>710</locationX>
+        <locationY>1634</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>Membership Form Submission Updated</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Insert_Success_Log</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>set_Error_Log_Values</name>
         <label>set Error Log Values</label>
         <locationX>1634</locationX>
@@ -454,7 +470,7 @@
         <name>Insert_Success_Log</name>
         <label>Insert Success Log</label>
         <locationX>710</locationX>
-        <locationY>1634</locationY>
+        <locationY>1742</locationY>
         <inputReference>soLogRecord</inputReference>
     </recordCreates>
     <recordLookups>
@@ -487,7 +503,7 @@
         <locationX>710</locationX>
         <locationY>1526</locationY>
         <connector>
-            <targetReference>Insert_Success_Log</targetReference>
+            <targetReference>Add_Log_Message_Updated_MFS</targetReference>
         </connector>
         <faultConnector>
             <targetReference>Create_MFS_Update_Error_Log</targetReference>

--- a/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
@@ -508,7 +508,7 @@
         <object>DPEV_Account__e</object>
         <triggerType>PlatformEvent</triggerType>
     </start>
-    <status>Draft</status>
+    <status>Active</status>
     <variables>
         <name>soAccount</name>
         <dataType>SObject</dataType>
@@ -532,7 +532,7 @@
         <isInput>false</isInput>
         <isOutput>false</isOutput>
         <value>
-            <stringValue>DPEV Listener - Create or Find Account</stringValue>
+            <stringValue>DPEV Listener - Find/Create Account</stringValue>
         </value>
     </variables>
     <variables>

--- a/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Create_or_Find_Account.flow-meta.xml
@@ -361,7 +361,7 @@
     <description>If the Organization Name is populated, attempts to find a matching Account using active duplicate rules. If duplicate rules are inactive or no match is found, creates a new Account.</description>
     <environments>Default</environments>
     <interviewLabel>DPEV Listener - {!$Flow.CurrentDateTime}</interviewLabel>
-    <label>DPEV Listener - Create or Find Account</label>
+    <label>DPEV Listener - Find/Create Account</label>
     <processMetadataValues>
         <name>BuilderType</name>
         <value>
@@ -508,7 +508,7 @@
         <object>DPEV_Account__e</object>
         <triggerType>PlatformEvent</triggerType>
     </start>
-    <status>Active</status>
+    <status>Draft</status>
     <variables>
         <name>soAccount</name>
         <dataType>SObject</dataType>

--- a/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
@@ -111,7 +111,7 @@
     <assignments>
         <name>set_Error_Log_Values</name>
         <label>set Error Log Values</label>
-        <locationX>1370</locationX>
+        <locationX>1106</locationX>
         <locationY>386</locationY>
         <assignmentItems>
             <assignToReference>soLogRecord.Log_Type__c</assignToReference>
@@ -143,6 +143,13 @@
                 <elementReference>StaticFlowName</elementReference>
             </value>
         </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue></stringValue>
+            </value>
+        </assignmentItems>
         <connector>
             <targetReference>Get_MFS_record</targetReference>
         </connector>
@@ -150,7 +157,7 @@
     <assignments>
         <name>set_MFS_Error_Values</name>
         <label>set MFS Error Values</label>
-        <locationX>1370</locationX>
+        <locationX>1106</locationX>
         <locationY>602</locationY>
         <assignmentItems>
             <assignToReference>Get_MFS_record.Status__c</assignToReference>
@@ -393,7 +400,7 @@
     <recordCreates>
         <name>insert_Error_Log</name>
         <label>insert Error Log</label>
-        <locationX>1370</locationX>
+        <locationX>1106</locationX>
         <locationY>494</locationY>
         <connector>
             <targetReference>set_MFS_Error_Values</targetReference>
@@ -448,7 +455,7 @@
         <description>Update MFS with the error values</description>
         <name>update_MFS</name>
         <label>update MFS</label>
-        <locationX>1370</locationX>
+        <locationX>1106</locationX>
         <locationY>710</locationY>
         <faultConnector>
             <isGoTo>true</isGoTo>
@@ -465,7 +472,7 @@
         <object>DPEV_Contact_Finder__e</object>
         <triggerType>PlatformEvent</triggerType>
     </start>
-    <status>Active</status>
+    <status>Draft</status>
     <variables>
         <name>soLogRecord</name>
         <dataType>SObject</dataType>

--- a/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
@@ -2,10 +2,10 @@
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <actionCalls>
         <description>Utilizes an Unofficial Salesforce component to identify duplicate records based on Salesforce&apos;s Duplicate Matching Rules. Input is firstName, lastName, email</description>
-        <name>Search_for_Duplicates</name>
-        <label>Search for Duplicates</label>
+        <name>Check_for_Contact_Matches</name>
+        <label>Check for Contact Matches</label>
         <locationX>314</locationX>
-        <locationY>494</locationY>
+        <locationY>602</locationY>
         <actionName>DuplicateRecordCheck_Invocable</actionName>
         <actionType>apex</actionType>
         <connector>
@@ -19,9 +19,6 @@
             <typeName>T__records</typeName>
             <typeValue>Contact</typeValue>
         </dataTypeMappings>
-        <faultConnector>
-            <targetReference>Search_for_Duplicates_Membership_Essentials_Log</targetReference>
-        </faultConnector>
         <flowTransactionModel>CurrentTransaction</flowTransactionModel>
         <inputParameters>
             <name>record</name>
@@ -34,10 +31,58 @@
     </actionCalls>
     <apiVersion>49.0</apiVersion>
     <assignments>
+        <name>Add_Log_Message_Created_Contact</name>
+        <label>Add Log Message - Created Contact</label>
+        <locationX>50</locationX>
+        <locationY>1034</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>New contact created; </stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>set_MFS_Success_Info_Created_Contact</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>Add_Log_Message_Found_Contact</name>
+        <label>Add Log Message - Found Contact</label>
+        <locationX>578</locationX>
+        <locationY>818</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>Found existing contact; </stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Update_MFS_Sucess</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>Add_Log_Message_No_Contact</name>
+        <label>Add Log Message - No Contact</label>
+        <locationX>50</locationX>
+        <locationY>818</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>No matching contact record found; </stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Create_Contact</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Fill_Temp_Contact_Variable</name>
         <label>Fill Temp Contact Variable</label>
         <locationX>314</locationX>
-        <locationY>386</locationY>
+        <locationY>494</locationY>
         <assignmentItems>
             <assignToReference>varTempContact.Email</assignToReference>
             <operator>Assign</operator>
@@ -60,14 +105,53 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Search_for_Duplicates</targetReference>
+            <targetReference>Check_for_Contact_Matches</targetReference>
         </connector>
     </assignments>
     <assignments>
-        <name>Update_MFS_Error_Create</name>
-        <label>Update MFS - Error</label>
+        <name>set_Error_Log_Values</name>
+        <label>set Error Log Values</label>
+        <locationX>1370</locationX>
+        <locationY>386</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Error</stringValue>
+            </value>
+        </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>Error: {!$Flow.FaultMessage}</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>insert_Error_Log</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_Initial_Log_Values</name>
+        <label>set Initial Log Values</label>
         <locationX>314</locationX>
-        <locationY>926</locationY>
+        <locationY>170</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Flow_Name__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>StaticFlowName</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Get_MFS_record</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_MFS_Error_Values</name>
+        <label>set MFS Error Values</label>
+        <locationX>1370</locationX>
+        <locationY>602</locationY>
         <assignmentItems>
             <assignToReference>Get_MFS_record.Status__c</assignToReference>
             <operator>Assign</operator>
@@ -79,19 +163,51 @@
             <assignToReference>Get_MFS_record.Failure_Information__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <stringValue>Unable to create contact record</stringValue>
+                <elementReference>varMFSFailureMessage</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>update_MFS</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_MFS_Failure_Message</name>
+        <label>set MFS Failure Message</label>
+        <locationX>314</locationX>
+        <locationY>1034</locationY>
+        <assignmentItems>
+            <assignToReference>Get_MFS_record.Failure_Information__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Unable to create new contact record</stringValue>
             </value>
         </assignmentItems>
         <connector>
             <isGoTo>true</isGoTo>
-            <targetReference>Update_MFS</targetReference>
+            <targetReference>Update_Membership_Form_Submission</targetReference>
         </connector>
     </assignments>
     <assignments>
-        <name>Update_MFS_Success</name>
-        <label>Update MFS - Success</label>
+        <name>set_MFS_Id_in_Log</name>
+        <label>set MFS Id in Log</label>
+        <locationX>314</locationX>
+        <locationY>386</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Membership_Form_Submission__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>Get_MFS_record.Id</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Fill_Temp_Contact_Variable</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
+        <name>set_MFS_Success_Info_Created_Contact</name>
+        <label>set MFS Success Info - Created Contact</label>
         <locationX>50</locationX>
-        <locationY>926</locationY>
+        <locationY>1142</locationY>
         <assignmentItems>
             <assignToReference>Get_MFS_record.Contact__c</assignToReference>
             <operator>Assign</operator>
@@ -100,53 +216,53 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Update_MFS</targetReference>
+            <targetReference>Update_Membership_Form_Submission</targetReference>
         </connector>
     </assignments>
     <assignments>
         <name>Update_MFS_Sucess</name>
         <label>Update MFS - Sucess</label>
         <locationX>578</locationX>
-        <locationY>818</locationY>
+        <locationY>926</locationY>
         <assignmentItems>
             <assignToReference>Get_MFS_record.Contact__c</assignToReference>
             <operator>Assign</operator>
             <value>
-                <elementReference>Search_for_Duplicates.duplicate.duplicateRecordId</elementReference>
+                <elementReference>Check_for_Contact_Matches.duplicate.duplicateRecordId</elementReference>
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Update_MFS</targetReference>
+            <targetReference>Update_Membership_Form_Submission</targetReference>
         </connector>
     </assignments>
     <decisions>
         <name>Found_Matching_Contact</name>
         <label>Found Matching Contact?</label>
         <locationX>314</locationX>
-        <locationY>602</locationY>
+        <locationY>710</locationY>
         <defaultConnector>
-            <targetReference>Create_Membership_Essentials_Log_Pass</targetReference>
+            <targetReference>Add_Log_Message_Found_Contact</targetReference>
         </defaultConnector>
         <defaultConnectorLabel>Match Found</defaultConnectorLabel>
         <rules>
             <name>No_Match_Found</name>
             <conditionLogic>or</conditionLogic>
             <conditions>
-                <leftValueReference>Search_for_Duplicates.isSuccess</leftValueReference>
+                <leftValueReference>Check_for_Contact_Matches.isSuccess</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <booleanValue>false</booleanValue>
                 </rightValue>
             </conditions>
             <conditions>
-                <leftValueReference>Search_for_Duplicates.duplicate.isDuplicate</leftValueReference>
+                <leftValueReference>Check_for_Contact_Matches.duplicate.isDuplicate</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
                     <booleanValue>false</booleanValue>
                 </rightValue>
             </conditions>
             <connector>
-                <targetReference>Create_Contact</targetReference>
+                <targetReference>Add_Log_Message_No_Contact</targetReference>
             </connector>
             <label>No Match Found</label>
         </rules>
@@ -184,12 +300,12 @@
         <name>Create_Contact</name>
         <label>Create Contact</label>
         <locationX>50</locationX>
-        <locationY>710</locationY>
+        <locationY>926</locationY>
         <connector>
-            <targetReference>Create_Membership_Essentials_Log_Pass1</targetReference>
+            <targetReference>Add_Log_Message_Created_Contact</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Create_Create_Contact_Membership_Essentials_Log</targetReference>
+            <targetReference>set_MFS_Failure_Message</targetReference>
         </faultConnector>
         <inputAssignments>
             <field>Email</field>
@@ -243,205 +359,10 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
     <recordCreates>
-        <name>Create_Create_Contact_Membership_Essentials_Log</name>
-        <label>Create &quot;Create Contact&quot; Membership Essentials Log</label>
-        <locationX>314</locationX>
-        <locationY>818</locationY>
-        <connector>
-            <targetReference>Update_MFS_Error_Create</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <elementReference>$Flow.FaultMessage</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Get_MFS_Contact_Membership_Essentials_Log</name>
-        <label>Create &quot;Get MFS Contact&quot; Membership Essentials Log</label>
-        <locationX>1370</locationX>
-        <locationY>386</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Initial_Membership_Essentials_Log</name>
-        <label>Create Initial Membership Essentials Log</label>
-        <locationX>1634</locationX>
-        <locationY>278</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>Platform event triggered. {!$Flow.FaultMessage}</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Membership_Essentials_Log_Pass</name>
-        <label>Create Membership Essentials Log - Pass</label>
-        <locationX>578</locationX>
-        <locationY>710</locationY>
-        <connector>
-            <targetReference>Update_MFS_Sucess</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>MFS Contact Found</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Pass</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Membership_Essentials_Log_Pass1</name>
-        <label>Create Membership Essentials Log - Pass</label>
-        <locationX>50</locationX>
-        <locationY>818</locationY>
-        <connector>
-            <targetReference>Update_MFS_Success</targetReference>
-        </connector>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>MFS Contact Created</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Pass</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Membership_Essentials_Log_Pass2</name>
-        <label>Create Membership Essentials Log - Pass</label>
-        <locationX>314</locationX>
-        <locationY>1316</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <stringValue>Membership Form Submission has been updated</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Pass</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Create_Update_MFS_Membership_Essentials_Log</name>
-        <label>Create &quot;Update MFS&quot; Membership Essentials Log</label>
+        <name>Create_MFS_Update_Error_Log</name>
+        <label>Create MFS Update Error Log</label>
         <locationX>842</locationX>
-        <locationY>1316</locationY>
+        <locationY>1442</locationY>
         <inputAssignments>
             <field>Flow_Name__c</field>
             <value>
@@ -470,73 +391,33 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
     <recordCreates>
-        <name>Search_for_Duplicates_Membership_Essentials_Log</name>
-        <label>&quot;Search for Duplicates&quot; Membership Essentials Log</label>
-        <locationX>1106</locationX>
-        <locationY>602</locationY>
-        <inputAssignments>
-            <field>Flow_Name__c</field>
-            <value>
-                <elementReference>StaticFlowName</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Message__c</field>
-            <value>
-                <elementReference>$Flow.FaultMessage</elementReference>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Log_Type__c</field>
-            <value>
-                <stringValue>Error</stringValue>
-            </value>
-        </inputAssignments>
-        <inputAssignments>
-            <field>Membership_Form_Submission__c</field>
-            <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>Membership_Essentials_Event_Log__c</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordLookups>
-        <description>Get the Contact from the MFS record</description>
-        <name>Get_MFS_Contact</name>
-        <label>Get MFS Contact</label>
-        <locationX>314</locationX>
-        <locationY>278</locationY>
-        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <name>insert_Error_Log</name>
+        <label>insert Error Log</label>
+        <locationX>1370</locationX>
+        <locationY>494</locationY>
         <connector>
-            <targetReference>Fill_Temp_Contact_Variable</targetReference>
+            <targetReference>set_MFS_Error_Values</targetReference>
         </connector>
-        <faultConnector>
-            <targetReference>Create_Get_MFS_Contact_Membership_Essentials_Log</targetReference>
-        </faultConnector>
-        <filterLogic>and</filterLogic>
-        <filters>
-            <field>Email</field>
-            <operator>EqualTo</operator>
-            <value>
-                <elementReference>Get_MFS_record.Email__c</elementReference>
-            </value>
-        </filters>
-        <getFirstRecordOnly>true</getFirstRecordOnly>
-        <object>Contact</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordLookups>
+        <inputReference>soLogRecord</inputReference>
+    </recordCreates>
+    <recordCreates>
+        <name>Insert_Success_Log</name>
+        <label>Insert Success Log</label>
+        <locationX>314</locationX>
+        <locationY>1442</locationY>
+        <inputReference>soLogRecord</inputReference>
+    </recordCreates>
     <recordLookups>
         <name>Get_MFS_record</name>
         <label>Get MFS record</label>
         <locationX>314</locationX>
-        <locationY>170</locationY>
+        <locationY>278</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>Get_MFS_Contact</targetReference>
+            <targetReference>set_MFS_Id_in_Log</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Create_Initial_Membership_Essentials_Log</targetReference>
+            <targetReference>set_Error_Log_Values</targetReference>
         </faultConnector>
         <filterLogic>and</filterLogic>
         <filters>
@@ -551,15 +432,27 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
     <recordUpdates>
-        <name>Update_MFS</name>
-        <label>Update MFS</label>
+        <name>Update_Membership_Form_Submission</name>
+        <label>Update Membership Form Submission</label>
         <locationX>314</locationX>
-        <locationY>1208</locationY>
+        <locationY>1334</locationY>
         <connector>
-            <targetReference>Create_Membership_Essentials_Log_Pass2</targetReference>
+            <targetReference>Insert_Success_Log</targetReference>
         </connector>
         <faultConnector>
-            <targetReference>Create_Update_MFS_Membership_Essentials_Log</targetReference>
+            <targetReference>Create_MFS_Update_Error_Log</targetReference>
+        </faultConnector>
+        <inputReference>Get_MFS_record</inputReference>
+    </recordUpdates>
+    <recordUpdates>
+        <description>Update MFS with the error values</description>
+        <name>update_MFS</name>
+        <label>update MFS</label>
+        <locationX>1370</locationX>
+        <locationY>710</locationY>
+        <faultConnector>
+            <isGoTo>true</isGoTo>
+            <targetReference>Create_MFS_Update_Error_Log</targetReference>
         </faultConnector>
         <inputReference>Get_MFS_record</inputReference>
     </recordUpdates>
@@ -567,12 +460,20 @@
         <locationX>188</locationX>
         <locationY>0</locationY>
         <connector>
-            <targetReference>Get_MFS_record</targetReference>
+            <targetReference>set_Initial_Log_Values</targetReference>
         </connector>
         <object>DPEV_Contact_Finder__e</object>
         <triggerType>PlatformEvent</triggerType>
     </start>
     <status>Active</status>
+    <variables>
+        <name>soLogRecord</name>
+        <dataType>SObject</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
+        <objectType>Membership_Essentials_Event_Log__c</objectType>
+    </variables>
     <variables>
         <name>StaticFlowName</name>
         <dataType>String</dataType>
@@ -582,6 +483,13 @@
         <value>
             <stringValue>DPEV Listener - Find/Create Contact</stringValue>
         </value>
+    </variables>
+    <variables>
+        <name>varMFSFailureMessage</name>
+        <dataType>String</dataType>
+        <isCollection>false</isCollection>
+        <isInput>false</isInput>
+        <isOutput>false</isOutput>
     </variables>
     <variables>
         <name>varTempContact</name>

--- a/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
@@ -9,7 +9,7 @@
         <actionName>DuplicateRecordCheck_Invocable</actionName>
         <actionType>apex</actionType>
         <connector>
-            <targetReference>Contact_Exists</targetReference>
+            <targetReference>Found_Matching_Contact</targetReference>
         </connector>
         <dataTypeMappings>
             <typeName>T__record</typeName>
@@ -120,17 +120,24 @@
         </connector>
     </assignments>
     <decisions>
-        <name>Contact_Exists</name>
-        <label>Contact Exists?</label>
+        <name>Found_Matching_Contact</name>
+        <label>Found Matching Contact?</label>
         <locationX>314</locationX>
         <locationY>602</locationY>
         <defaultConnector>
             <targetReference>Create_Membership_Essentials_Log_Pass</targetReference>
         </defaultConnector>
-        <defaultConnectorLabel>Yes, Find</defaultConnectorLabel>
+        <defaultConnectorLabel>Match Found</defaultConnectorLabel>
         <rules>
-            <name>No_Create</name>
-            <conditionLogic>and</conditionLogic>
+            <name>No_Match_Found</name>
+            <conditionLogic>or</conditionLogic>
+            <conditions>
+                <leftValueReference>Search_for_Duplicates.isSuccess</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
             <conditions>
                 <leftValueReference>Search_for_Duplicates.duplicate.isDuplicate</leftValueReference>
                 <operator>EqualTo</operator>
@@ -141,10 +148,10 @@
             <connector>
                 <targetReference>Create_Contact</targetReference>
             </connector>
-            <label>No, Create</label>
+            <label>No Match Found</label>
         </rules>
     </decisions>
-    <description>PE triggered flow, finds or creates a contact from Membership Submission Form record.</description>
+    <description>PE triggered flow, attempts to find a matching Contact using active duplicate rules. If duplicate rules are inactive or no match is found, creates a new contact.</description>
     <environments>Default</environments>
     <formulas>
         <description>Combines the two street address lines</description>
@@ -476,7 +483,7 @@
         <inputAssignments>
             <field>Log_Message__c</field>
             <value>
-                <elementReference>Get_MFS_record.Id</elementReference>
+                <elementReference>$Flow.FaultMessage</elementReference>
             </value>
         </inputAssignments>
         <inputAssignments>

--- a/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
@@ -90,6 +90,13 @@
                 <stringValue>Membership Form Submission Updated</stringValue>
             </value>
         </assignmentItems>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Type__c</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <stringValue>Pass</stringValue>
+            </value>
+        </assignmentItems>
         <connector>
             <targetReference>Insert_Success_Log</targetReference>
         </connector>

--- a/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
@@ -79,6 +79,22 @@
         </connector>
     </assignments>
     <assignments>
+        <name>Add_Log_Message_Updated_MFS</name>
+        <label>Add Log Message - Updated MFS</label>
+        <locationX>314</locationX>
+        <locationY>1442</locationY>
+        <assignmentItems>
+            <assignToReference>soLogRecord.Log_Message__c</assignToReference>
+            <operator>Add</operator>
+            <value>
+                <stringValue>Membership Form Submission Updated</stringValue>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Insert_Success_Log</targetReference>
+        </connector>
+    </assignments>
+    <assignments>
         <name>Fill_Temp_Contact_Variable</name>
         <label>Fill Temp Contact Variable</label>
         <locationX>314</locationX>
@@ -411,7 +427,7 @@
         <name>Insert_Success_Log</name>
         <label>Insert Success Log</label>
         <locationX>314</locationX>
-        <locationY>1442</locationY>
+        <locationY>1550</locationY>
         <inputReference>soLogRecord</inputReference>
     </recordCreates>
     <recordLookups>
@@ -444,7 +460,7 @@
         <locationX>314</locationX>
         <locationY>1334</locationY>
         <connector>
-            <targetReference>Insert_Success_Log</targetReference>
+            <targetReference>Add_Log_Message_Updated_MFS</targetReference>
         </connector>
         <faultConnector>
             <targetReference>Create_MFS_Update_Error_Log</targetReference>
@@ -472,7 +488,7 @@
         <object>DPEV_Contact_Finder__e</object>
         <triggerType>PlatformEvent</triggerType>
     </start>
-    <status>Draft</status>
+    <status>Active</status>
     <variables>
         <name>soLogRecord</name>
         <dataType>SObject</dataType>

--- a/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Find_Create_Contact.flow-meta.xml
@@ -267,7 +267,7 @@
             <label>No Match Found</label>
         </rules>
     </decisions>
-    <description>PE triggered flow, attempts to find a matching Contact using active duplicate rules. If duplicate rules are inactive or no match is found, creates a new contact.</description>
+    <description>Attempts to find a matching Contact using active duplicate rules. If duplicate rules are inactive or no match is found, creates a new Contact.</description>
     <environments>Default</environments>
     <formulas>
         <description>Combines the two street address lines</description>


### PR DESCRIPTION
Testing notes:
- test with and without matching rules active for the desired object AND with an existing account/contact that matches
- additionally, review logs for updated text and accuracy

# Critical Changes

Account and contact flows will only attempt to find matching records IF the org has at least one active duplicate rule. Otherwise a new account/contact will be created.

# Changes

# Issues Closed