### PR TITLE
Fix the Membership Finder flow: API 49 cannot run its Transform element

### DIFF
--- a/force-app/main/default/flows/DPEV_Listener_Membership_Finder.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Membership_Finder.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <assignments>
         <description>Assign the Membership Form Submission to a record variable to updated</description>
         <name>AssignMembershipFormSubmissionforUpdate</name>

--- a/force-app/main/default/objects/Membership_Essentials_Event_Log__c/listViews/All.listView-meta.xml
+++ b/force-app/main/default/objects/Membership_Essentials_Event_Log__c/listViews/All.listView-meta.xml
@@ -2,6 +2,7 @@
 <ListView xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>All</fullName>
     <columns>NAME</columns>
+    <columns>Membership_Form_Submission__c</columns>
     <columns>Flow_Name__c</columns>
     <columns>Log_Type__c</columns>
     <columns>CREATED_DATE</columns>


### PR DESCRIPTION
## What this fixes

`DPEV_Listener_Membership_Finder` declares `apiVersion 49.0` but uses a `<transforms>` element (`Get_Matching_Products[$EachItem].Id`), which requires API 59 or later. Every run of the flow died at that element:

```
FLOW_ELEMENT_ERROR|Syntax error.  Found 'Get_Matching_Products'|FlowTransform|Matching_Product_ID_List
```

It is the only flow in the repo using `<transforms>`, which is why it is the only one this bites.

The failure was invisible. The `faultConnector` sits on the preceding record lookup rather than on the transform, so the crash produced no log row, no error email, and no change to the submission — the flow just stopped, leaving `Membership_Finder_Ran__c` permanently `false`.

This raises the flow to API 62 and adds Membership Form Submission to the event log's **All** list view, so log rows can be read per submission.

## Provenance

Per `AGENTS.md`, splitting what was run from what was read:

**Reproduced in a scratch org.** The API version bug, the crash, and the fix. Before the bump, `DPEV_Listener_Membership_Finder` had produced **zero** `Membership_Essentials_Event_Log__c` rows in the org's entire lifetime. After it, `Membership_Finder_Ran__c` flips to `true` and the finder logs `NO Membership found` as designed. Confirmed independently at API 59 and at API 62.

**Read from metadata, not reproduced.** The claim that API 59 is the specific floor for `$EachItem` — the bump was tested, the exact minimum was not bisected.

## What this does *not* fix

Worth stating plainly so nobody reads this as "membership creation works now." It does not. A normal submission still ends `Imported` with no `Membership__c`, for reasons outside this diff:

- The orchestrator publishes the finder event and marks the submission `Imported` in the **same pass**. `Membership_Form_Submission_AFTER_MFS_auditor` excludes `Imported`, so it never re-enters to consume the flag. Forcing one re-entry by hand *does* produce a Membership and a Membership Contact Role — the downstream path is healthy, just unreachable in a single pass.
- `Is_The_Opportunity_Lookup_Set` evaluates `Opportunity_Exists` first and jumps straight to `Update_MFS_status_Imported`, so the membership branch is only reachable with `Do_not_create_Opportunity__c = true` — and on that route `BPEV_Listener_Membership_Transaction` requires an Opportunity and dead-ends with no default connector.

Those are design questions for the group rather than something to patch unilaterally, so they are left out of this PR.

## Deliberately left behind

`retrieve_changes` reported 24 components; 11 more came back changed but are scratch-org round-trip churn, not work:

- **Dashboard** — `owner`/`runningUser` rewritten to this scratch org's username.
- **Layouts** (Account, Contact, Membership Log) — `runtime_sales_social:socialPanel` dropped because the feature is off in the org; two empty `<layoutColumns/>` added.
- **Formula fields** (`Term_Tier__c`, `Tier__c`, `Level__c`, `Is_Active__c`, `Term_Start_Date__c`) — `formulaTreatBlanksAs` removed, `precision` normalized 5 → 18, `trackHistory` toggled.
- **Reports** — `dateGranularity` set to `Day` on groupings that are not dates, plus chart defaults materialized on retrieve.

`GenOpAgentConfig: DPEV_Listener_Membership_Finder` was excluded at retrieve time as autogenerated, and `Profile: Admin` is covered by `.forceignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)