### PR TITLE
Fix the MFS chain: a submission now creates and links its Membership

### DIFF
--- a/force-app/main/default/flows/BPEV_Listener_Membership_Transaction.flow-meta.xml
+++ b/force-app/main/default/flows/BPEV_Listener_Membership_Transaction.flow-meta.xml
@@ -103,27 +103,12 @@
         </rules>
     </decisions>
     <decisions>
-        <description>Checks whether the Membership Finder has not already run.</description>
+        <description>Fires the create event once the finder has reported back. Deliberately does NOT publish the finder event when the flag is false: the orchestrator already publishes DPEV_Membership_Finder__e for every submission, and publishing it here as well ran two finder interviews in the same second, each of which republished this event and produced a duplicate Membership.</description>
         <name>Membership_Finder_Run_Check</name>
         <label>Membership Finder Run Check</label>
         <locationX>314</locationX>
         <locationY>494</locationY>
         <defaultConnectorLabel>Default Outcome</defaultConnectorLabel>
-        <rules>
-            <name>Membership_Finder_Has_Not_Run</name>
-            <conditionLogic>and</conditionLogic>
-            <conditions>
-                <leftValueReference>Query_for_Membership_Form_Submission.Membership_Finder_Ran__c</leftValueReference>
-                <operator>EqualTo</operator>
-                <rightValue>
-                    <booleanValue>false</booleanValue>
-                </rightValue>
-            </conditions>
-            <connector>
-                <targetReference>Fire_Membership_Finder_Platform_Event</targetReference>
-            </connector>
-            <label>NOT RUN Membership Finder Has Not Run</label>
-        </rules>
         <rules>
             <name>Membership_Finder_Has_Run</name>
             <conditionLogic>and</conditionLogic>
@@ -285,20 +270,6 @@
             </value>
         </inputAssignments>
         <object>DPEV_Membership_Downgrade__e</object>
-        <storeOutputAutomatically>true</storeOutputAutomatically>
-    </recordCreates>
-    <recordCreates>
-        <name>Fire_Membership_Finder_Platform_Event</name>
-        <label>Fire Membership Finder Platform Event</label>
-        <locationX>50</locationX>
-        <locationY>602</locationY>
-        <inputAssignments>
-            <field>Record_Id__c</field>
-            <value>
-                <elementReference>Query_for_Membership_Form_Submission.Id</elementReference>
-            </value>
-        </inputAssignments>
-        <object>DPEV_Membership_Finder__e</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
     <recordCreates>

--- a/force-app/main/default/flows/BPEV_Listener_Membership_Transaction.flow-meta.xml
+++ b/force-app/main/default/flows/BPEV_Listener_Membership_Transaction.flow-meta.xml
@@ -295,7 +295,7 @@
         <inputAssignments>
             <field>Record_Id__c</field>
             <value>
-                <elementReference>$Record.Record_Id__c</elementReference>
+                <elementReference>Query_for_Membership_Form_Submission.Id</elementReference>
             </value>
         </inputAssignments>
         <object>DPEV_Membership_Finder__e</object>

--- a/force-app/main/default/flows/BPEV_Listener_Membership_Transaction.flow-meta.xml
+++ b/force-app/main/default/flows/BPEV_Listener_Membership_Transaction.flow-meta.xml
@@ -131,7 +131,7 @@
                 <leftValueReference>Query_for_Membership_Form_Submission.Membership_Finder_Ran__c</leftValueReference>
                 <operator>EqualTo</operator>
                 <rightValue>
-                    <booleanValue>false</booleanValue>
+                    <booleanValue>true</booleanValue>
                 </rightValue>
             </conditions>
             <connector>
@@ -400,13 +400,14 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
     <recordLookups>
-        <name>Query_for_Membership_Form_Submission</name>
-        <label>Query for Membership Form Submission</label>
+        <description>The BPEV_Membership_Transaction__e payload carries an OpportunityLineItem Id in Record_Id__c (set by Opportunity_Line_Item_After_Membership). Resolve it here so the Membership Form Submission can be reached through its Opportunity, the same way DPEV_Listener_Membership_Create_Flow does it.</description>
+        <name>Get_Opportunity_Line_Item</name>
+        <label>Get Opportunity Line Item</label>
         <locationX>1546</locationX>
-        <locationY>170</locationY>
+        <locationY>62</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>Get_New_Product_ID</targetReference>
+            <targetReference>Query_for_Membership_Form_Submission</targetReference>
         </connector>
         <filterLogic>and</filterLogic>
         <filters>
@@ -417,6 +418,27 @@
             </value>
         </filters>
         <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>OpportunityLineItem</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
+        <name>Query_for_Membership_Form_Submission</name>
+        <label>Query for Membership Form Submission</label>
+        <locationX>1546</locationX>
+        <locationY>170</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Get_New_Product_ID</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>Opportunity__c</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>Get_Opportunity_Line_Item.OpportunityId</elementReference>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
         <object>Membership_Form_Submission__c</object>
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
@@ -424,7 +446,7 @@
         <locationX>1420</locationX>
         <locationY>0</locationY>
         <connector>
-            <targetReference>Query_for_Membership_Form_Submission</targetReference>
+            <targetReference>Get_Opportunity_Line_Item</targetReference>
         </connector>
         <object>BPEV_Membership_Transaction__e</object>
         <triggerType>PlatformEvent</triggerType>

--- a/force-app/main/default/flows/DPEV_Listener_Membership_Create_Flow.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Membership_Create_Flow.flow-meta.xml
@@ -2,6 +2,43 @@
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>61.0</apiVersion>
     <decisions>
+        <description>Idempotency and payload guard. Create exactly once: skip when the line item or submission could not be resolved, or when the submission already carries a Membership (a second create event for the same submission must be a no-op).</description>
+        <name>Should_Create_Membership</name>
+        <label>Should Create Membership</label>
+        <locationX>176</locationX>
+        <locationY>350</locationY>
+        <defaultConnectorLabel>Already handled or unresolved</defaultConnectorLabel>
+        <rules>
+            <name>Create_Is_Needed</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Query_Opportunity_Product.Id</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Query_Membership_Form_Submission.Id</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>Query_Membership_Form_Submission.Membership__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Create_Membership_Essentials_Log_Pass1</targetReference>
+            </connector>
+            <label>Create Is Needed</label>
+        </rules>
+    </decisions>
+    <decisions>
         <name>Does_Recipient_Exist</name>
         <label>Does Recipient Exist</label>
         <locationX>314</locationX>
@@ -533,7 +570,7 @@ TEXT({!$Flow.CurrentDate})
         <locationY>386</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
-            <targetReference>Create_Membership_Essentials_Log_Pass1</targetReference>
+            <targetReference>Should_Create_Membership</targetReference>
         </connector>
         <faultConnector>
             <targetReference>Create_Query_Membership_Form_Submission_Membership_Essentials_Log</targetReference>

--- a/force-app/main/default/flows/DPEV_Listener_Membership_Finder.flow-meta.xml
+++ b/force-app/main/default/flows/DPEV_Listener_Membership_Finder.flow-meta.xml
@@ -15,7 +15,7 @@
             </value>
         </assignmentItems>
         <connector>
-            <targetReference>Get_Matching_Products</targetReference>
+            <targetReference>Should_Finder_Proceed</targetReference>
         </connector>
     </assignments>
     <assignments>
@@ -25,14 +25,14 @@
         <locationX>50</locationX>
         <locationY>926</locationY>
         <assignmentItems>
-            <assignToReference>GetMembershipFormSubmission.Membership__c</assignToReference>
+            <assignToReference>MembershipFormSubmissionforUpdate.Membership__c</assignToReference>
             <operator>Assign</operator>
             <value>
                 <elementReference>GetMembership.Id</elementReference>
             </value>
         </assignmentItems>
         <assignmentItems>
-            <assignToReference>GetMembershipFormSubmission.Membership_Finder_Ran__c</assignToReference>
+            <assignToReference>MembershipFormSubmissionforUpdate.Membership_Finder_Ran__c</assignToReference>
             <operator>Assign</operator>
             <value>
                 <booleanValue>true</booleanValue>
@@ -59,6 +59,68 @@
             <targetReference>Create_Membership_Essentials_Log_Pass1</targetReference>
         </connector>
     </assignments>
+    <decisions>
+        <description>Skip when the submission was not found, the finder already ran, or a Membership is already linked. Without this guard the finder can be entered twice for one submission (once from the orchestrator, once from the transaction listener) and would publish two create events.</description>
+        <name>Should_Finder_Proceed</name>
+        <label>Should Finder Proceed</label>
+        <locationX>842</locationX>
+        <locationY>350</locationY>
+        <defaultConnectorLabel>Already handled</defaultConnectorLabel>
+        <rules>
+            <name>Finder_Should_Run</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>GetMembershipFormSubmission.Id</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>GetMembershipFormSubmission.Membership_Finder_Ran__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>GetMembershipFormSubmission.Membership__c</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Get_Matching_Products</targetReference>
+            </connector>
+            <label>Finder Should Run</label>
+        </rules>
+    </decisions>
+    <decisions>
+        <name>Fire_Transaction_For_Create</name>
+        <label>Fire Transaction For Create</label>
+        <locationX>314</locationX>
+        <locationY>1178</locationY>
+        <defaultConnector>
+            <targetReference>UpdateMembershipFormSubmission</targetReference>
+        </defaultConnector>
+        <defaultConnectorLabel>No Opportunity Line Item</defaultConnectorLabel>
+        <rules>
+            <name>OLI_Found</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>Get_OLI_For_Transaction.Id</leftValueReference>
+                <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Fire_Membership_Transaction_For_Create</targetReference>
+            </connector>
+            <label>OLI Found</label>
+        </rules>
+    </decisions>
     <decisions>
         <description>check if matches are found</description>
         <name>Matching_Product_Check</name>
@@ -270,7 +332,7 @@
         <locationX>314</locationX>
         <locationY>1034</locationY>
         <connector>
-            <targetReference>UpdateMembershipFormSubmission</targetReference>
+            <targetReference>Get_OLI_For_Transaction</targetReference>
         </connector>
         <inputAssignments>
             <field>Flow_Name__c</field>
@@ -332,10 +394,31 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordCreates>
     <recordCreates>
+        <description>Republish the transaction event now that Membership_Finder_Ran__c is true. The flag update in this same interview commits before the event is delivered (publish-after-commit), so the listener re-enters on its Membership_Finder_Has_Run rule and fires DPEV_Create_Membership__e.</description>
+        <name>Fire_Membership_Transaction_For_Create</name>
+        <label>Fire Membership Transaction For Create</label>
+        <locationX>314</locationX>
+        <locationY>1250</locationY>
+        <connector>
+            <targetReference>UpdateMembershipFormSubmission</targetReference>
+        </connector>
+        <inputAssignments>
+            <field>Record_Id__c</field>
+            <value>
+                <elementReference>Get_OLI_For_Transaction.Id</elementReference>
+            </value>
+        </inputAssignments>
+        <object>BPEV_Membership_Transaction__e</object>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordCreates>
+    <recordCreates>
         <name>Log_No_Matching_Products</name>
         <label>Log No Matching Products</label>
         <locationX>1370</locationX>
         <locationY>602</locationY>
+        <connector>
+            <targetReference>SetMembershipFinderRanFlag</targetReference>
+        </connector>
         <inputAssignments>
             <field>Flow_Name__c</field>
             <value>
@@ -396,6 +479,38 @@
         <storeOutputAutomatically>true</storeOutputAutomatically>
     </recordLookups>
     <recordLookups>
+        <description>The not-found path needs the Opportunity Line Item so it can republish BPEV_Membership_Transaction__e, whose Record_Id__c carries an OpportunityLineItem Id. The extra IsNull filter makes this lookup return nothing when the submission has no Opportunity (e.g. Do_not_create_Opportunity__c or the finder outran opportunity creation), instead of matching on null.</description>
+        <name>Get_OLI_For_Transaction</name>
+        <label>Get OLI For Transaction</label>
+        <locationX>314</locationX>
+        <locationY>1106</locationY>
+        <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
+        <connector>
+            <targetReference>Fire_Transaction_For_Create</targetReference>
+        </connector>
+        <filterLogic>and</filterLogic>
+        <filters>
+            <field>OpportunityId</field>
+            <operator>EqualTo</operator>
+            <value>
+                <elementReference>MembershipFormSubmissionforUpdate.Opportunity__c</elementReference>
+            </value>
+        </filters>
+        <filters>
+            <field>OpportunityId</field>
+            <operator>IsNull</operator>
+            <value>
+                <booleanValue>false</booleanValue>
+            </value>
+        </filters>
+        <getFirstRecordOnly>true</getFirstRecordOnly>
+        <object>OpportunityLineItem</object>
+        <queriedFields>Id</queriedFields>
+        <sortField>CreatedDate</sortField>
+        <sortOrder>Asc</sortOrder>
+        <storeOutputAutomatically>true</storeOutputAutomatically>
+    </recordLookups>
+    <recordLookups>
         <description>Query for a Membership record 
 where Account__c = Opportunity.AccountId 
 where End_Date__c &gt; today 
@@ -417,6 +532,13 @@ and the Product is a renewable membership of the same Category.</description>
             <operator>EqualTo</operator>
             <value>
                 <elementReference>GetMembershipFormSubmission.Account__r.Id</elementReference>
+            </value>
+        </filters>
+        <filters>
+            <field>Account__c</field>
+            <operator>IsNull</operator>
+            <value>
+                <booleanValue>false</booleanValue>
             </value>
         </filters>
         <filters>

--- a/force-app/main/default/permissionsets/Membership_Manage.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Membership_Manage.permissionset-meta.xml
@@ -719,8 +719,12 @@
         <visibility>Visible</visibility>
     </tabSettings>
     <tabSettings>
+        <tab>Membership_Essentials_Event_Log__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
         <tab>Membership_Form_Submission__c</tab>
-        <visibility>Available</visibility>
+        <visibility>Visible</visibility>
     </tabSettings>
     <tabSettings>
         <tab>Membership__c</tab>

--- a/force-app/main/default/permissionsets/Membership_View.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Membership_View.permissionset-meta.xml
@@ -483,6 +483,15 @@
         <allowEdit>false</allowEdit>
         <allowRead>true</allowRead>
         <modifyAllRecords>false</modifyAllRecords>
+        <object>Membership_Essentials_Event_Log__c</object>
+        <viewAllRecords>false</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>false</allowDelete>
+        <allowEdit>false</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>false</modifyAllRecords>
         <object>Account</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
@@ -531,6 +540,10 @@
         <object>Product2</object>
         <viewAllRecords>false</viewAllRecords>
     </objectPermissions>
+    <tabSettings>
+        <tab>Membership_Essentials_Event_Log__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
     <tabSettings>
         <tab>Membership__c</tab>
         <visibility>Visible</visibility>


### PR DESCRIPTION
## What this fixes

A Membership Form Submission **never created a `Membership__c`** — it produced a Contact, an Opportunity, an OpportunityLineItem and a trail of Pass logs, then marked itself `Status__c = Imported` anyway. With this PR, a submission creates and links its Membership end to end.

**Proven on a scratch org built from this branch** (insert an MFS with blank Status via anonymous Apex, poll for the linked Membership):

| Scenario | Result |
|---|---|
| plain submission, no Account | GREEN ~10s — 1 Membership, linked |
| submission with an Account | GREEN ~10s — 1 Membership, linked |
| every product `One-Time` (unseeded-org configuration) | GREEN ~10s — 1 Membership, linked |
| Household type / different SKU | GREEN ~10s — 1 Membership, linked |
| **9 consecutive submissions** after the dedup fix | **0 duplicates**, each completed one carrying exactly 1 Membership + 1 Primary Member MCR |

Verified twice over: first on an org built from this branch, then re-validated end to end on a **brand-new scratch org built with `cci flow run dev_org`** loading only this branch, to confirm the sprint's work holds together in isolation.

Per `AGENTS.md`: everything below marked *(runtime)* was verified with `FLOW_RULE_DETAIL`/`FLOW_ELEMENT_*` traces on the **Automated Process** user in a live org; *(metadata)* means read from the XML.

## Why no membership was ever created

Four independent defects stacked on the same path:

1. *(runtime)* **`BPEV_Listener_Membership_Transaction` misread its event payload.** `Opportunity_Line_Item_After_Membership` publishes `BPEV_Membership_Transaction__e` with `Record_Id__c = $Record.Id` — an **OpportunityLineItem Id**. The listener's first element queried `Membership_Form_Submission__c WHERE Id = <that OLI Id>`, with no fault connector: silent death on every event, zero log rows in the org's entire life. Differential proof on one OLI Id: publishing `DPEV_Create_Membership__e` created a Membership + 4 log rows; publishing `BPEV_Membership_Transaction__e` produced nothing.
2. *(metadata, unreachable at runtime until #1 was fixed)* **A copy-paste dead rule.** In `Membership_Finder_Run_Check`, both rules tested `Membership_Finder_Ran__c = false`, so `Fire_Create_Membership_Platform_Event` could never fire.
3. *(runtime)* **The finder's Found branch discarded its own writes.** It assigned `Membership__c` and `Membership_Finder_Ran__c` to `GetMembershipFormSubmission`, but the update element saves `MembershipFormSubmissionforUpdate` — 3 clean DML statements, both values thrown away.
4. *(runtime)* **Nothing ever re-entered after the finder ran.** The orchestrator marks `Imported` in the same pass, and the MFS auditor excludes `Imported`, so the listener's "finder has run → fire create" branch was unreachable. The create flow itself was healthy all along — publishing its event by hand created a Membership immediately.

Plus two matching bugs that made things worse:

5. *(runtime)* **The finder matched strangers' memberships.** With no Account on the submission, `GetMembership`'s filter degraded to `Account__c = null` and matched an unrelated person's account-less Membership ("Membership Found" observed live against another contact's record).
6. *(runtime)* **Fresh orgs died even earlier.** `Get_Matching_Products` requires `Renewal_Option__c = 'Renewable'`, but `One-Time` is the picklist default and the sample dataset ships every product as `One-Time` — so out of the box the finder logged "No Matching Products Found - can't proceed" on every submission and dead-ended without setting its flag.

## The solution (7 changes, 3 flows)

**`DPEV_Listener_Membership_Finder`**
- **A** — `GetMembership` gains an `Account__c IsNull false` filter: a blank submission Account can no longer null-match a blank membership Account (fixes #5).
- **B** — the Found branch now assigns to `MembershipFormSubmissionforUpdate`, the variable the update element actually saves (fixes #3).
- **C** — new entry guard: exit if the submission is missing, the finder already ran, or a Membership is already linked. The finder is fired from two places (orchestrator + transaction listener); without this the second pass would double-publish.
- **D** — "no Renewable products" now proceeds to the not-found path instead of dead-ending: no candidate products means there is definitively no existing membership to find (fixes #6 at runtime; the dataset/filter mismatch is still worth a look).
- **E** — the not-found path republishes `BPEV_Membership_Transaction__e` (guarded: only when an OpportunityLineItem exists). This completes the handshake the listener's `Membership_Finder_Has_Run` rule was designed for (fixes #4). The flag update commits before the event delivers (publish-after-commit), so the listener re-enters seeing `true`.

**`BPEV_Listener_Membership_Transaction`**
- **F** — resolves its payload OLI → Opportunity → MFS, the same convention `DPEV_Listener_Membership_Create_Flow` already uses (fixes #1); `Membership_Finder_Has_Run` now tests `true` (fixes #2); and `Fire_Membership_Finder_Platform_Event` passes the **MFS Id** instead of forwarding the OLI Id into an MFS-Id consumer — the source of the orphan "Membership Found" log rows.
- **H** — removed the redundant `Membership_Finder_Has_Not_Run` rule and its publish element. Fixing F made this listener's finder publish work for the first time, which meant the finder event was published **twice** per submission (orchestrator + here) — two interviews in the same second, both reading the flag as false, both republishing, two create events, duplicate Membership. Measured at 2 duplicates in 5 runs on submissions with a single Opportunity and a single line item, so distinct from #260. The orchestrator publishes the finder event for every submission, so this listener only needs its `Membership_Finder_Has_Run → Fire_Create` branch. **After: 0 duplicates in 9 runs.**

**`DPEV_Listener_Membership_Create_Flow`**
- **G** — guard before creation: skip when the line item or submission is unresolved, or the submission already carries a Membership. Makes a duplicate create event a no-op, and stops the null-contamination path (unresolvable OLI → `Opportunity__c = null` grabbing an arbitrary submission) from ever reaching `Create_Membership`.

Also here, from a report by @DebNevin: the **Membership Essentials Event Log tab** was unreachable — the object was granted but no permission set carried the tab, which defaults to Hidden. `Membership_Manage` and `Membership_View` now grant it (and `Membership_View` gains read on the object). The Admin profile can't carry it: `.forceignore` excludes `**/profiles`.

## Known residuals — documented, deliberately not fixed here

- **Duplicate Opportunities from the auditor re-fire, and a same-second duplicate-Membership window.** The MFS auditor re-fires on every listener's update; two of three test runs got 2 Opportunities created in the same second (this predates this PR — observable in any org today). Guard G catches the duplicate create when events serialize (run 3: 2 opps → 1 membership) but one run raced two create interviews inside the same second past it (run 2). Flows cannot lock across transactions; this closes when the duplicate-Opportunity defect closes.
- **`Do_not_create_Opportunity__c = true` still cannot create a Membership** — creation is driven from the OpportunityLineItem. Design question for the group, unchanged here.
- Filed from this work, out of scope here: #260 auditor storm · #261 Event Log integrity (unconditional "Pass" logs, orphaned finder rows) · #262 `Failed` resurrects · #263 Membership left half-populated (no Account, unresolved name, blank MCR fields) · #264 sample dataset ships no PricebookEntries so the first submission in a fresh org fails · #265 the `Do_not_create_Opportunity__c` route can't create a Membership (design call) · #268 stalled submissions.
- Proposals, for discussion rather than this PR: #266 populate `Origin__c` (the field exists with the right values; nothing writes it — it is the missing dimension for term-over-term reporting) · #267 a direct membership-term import path so orgs whose memberships live in Opportunities or a ticketing system don't have to fake Form Submissions to load history.

## How to verify

```
cci flow run dev_org --org <name>    # from this branch
# NOTE: seed PricebookEntries first — see #264, the dataset ships none
# and the first submission otherwise fails with "No Pricebook Entry Found"
# insert via anonymous Apex:
insert new Membership_Form_Submission__c(FirstName__c='QA', LastName__c='Test',
    Email__c='qa@example.invalid', MembershipType__c='Individual',
    Duration__c='1 Year', Product_SKU__c='BSC', SalePrice__c=100);
# ~10s later the MFS should carry Membership__c, Membership_Finder_Ran__c=true,
# and exactly one Membership + Primary Member MCR should exist for the contact.
#
# Cloning an existing MFS to test does NOT work: the clone carries
# Status__c=Imported, which the auditor's entry criteria excludes, so nothing
# fires. Clear Status and Membership_Finder_Ran__c, and keep a Product SKU.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
